### PR TITLE
Add print_detailed() API to DSync and DSyncModel classes

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -16,10 +16,15 @@ from backend_c import BackendC
 
 a = BackendA()
 a.load()
+a.print_detailed()
+
 b = BackendB()
 b.load()
+b.print_detailed()
+
 c = BackendC()
 c.load()
+c.print_detailed()
 ```
 
 Configure verbosity of DSync's structured logging to console; the default is full verbosity (all logs including debugging)

--- a/examples/example1/main.py
+++ b/examples/example1/main.py
@@ -32,14 +32,17 @@ def main():
     print("Initializing and loading Backend A...")
     backend_a = BackendA(name="Backend-A")
     backend_a.load()
+    backend_a.print_detailed()
 
     print("Initializing and loading Backend B...")
     backend_b = BackendB(name="Backend-B")
     backend_b.load()
+    backend_b.print_detailed()
 
     print("Initializing and loading Backend C...")
     backend_c = BackendC()
     backend_c.load()
+    backend_c.print_detailed()
 
     print("Getting diffs from Backend A to Backend B...")
     diff_a_b = backend_a.diff_to(backend_b, diff_class=MyDiff)


### PR DESCRIPTION
In troubleshooting some issues with implementing a custom `load()` method, I found it useful to have a utility method for printing the contents of a single `DSync` in a similar format to how we can already print the contents of a `Diff`.

At some point we should change all of the `print_detailed` methods to return a constructed `str` object instead of just printing it, so that we can use this output in logs and such, but for now at least we're self-consistent.

Example output:

```
site
  site: nyc
    device
      device: nyc-spine1
        interface
          interface: nyc-spine1__eth0
          interface: nyc-spine1__eth1
      device: nyc-spine2
        interface
          interface: nyc-spine2__eth0
          interface: nyc-spine2__eth1
  site: sfo
    device
      device: sfo-spine1
        interface
          interface: sfo-spine1__eth0
          interface: sfo-spine1__eth1
      device: sfo-spine2
        interface
          interface: sfo-spine2__eth0
          interface: sfo-spine2__eth1
          interface: sfo-spine2__eth2
```

Another example, showing a case I'm currently troubleshooting where we have child objects referenced in a `DSyncModel` but not found in the corresponding `DSync` data:

```
location
  location: USA
    device
      (none)
    prefix
      (none)
    location
      NYC (no details available)
      ATL (no details available)
      RDU (no details available)
    vlan
      (none)
  location: LON
    device
      (none)
    prefix
      (none)
    location
      (none)
    vlan
      (none)
```