### PR TITLE
Add "summary" method to Diff/DiffElement, fix an issue in DiffElement.dict()

### DIFF
--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -101,6 +101,7 @@ class Diff:
             "create": 0,
             "update": 0,
             "delete": 0,
+            "no-change": 0,
         }
         for child in self.get_children():
             child_summary = child.summary()
@@ -316,9 +317,12 @@ class DiffElement:  # pylint: disable=too-many-instance-attributes
             "create": 0,
             "update": 0,
             "delete": 0,
+            "no-change": 0,
         }
         if self.action:
             summary[self.action] += 1
+        else:
+            summary["no-change"] += 1
         child_summary = self.child_diff.summary()
         for key in summary:
             summary[key] += child_summary[key]

--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -95,6 +95,19 @@ class Diff:
         for child in children.values():
             yield child
 
+    def summary(self) -> Mapping[Text, int]:
+        """Build a dict summary of this Diff and its child DiffElements."""
+        summary = {
+            "create": 0,
+            "update": 0,
+            "delete": 0,
+        }
+        for child in self.get_children():
+            child_summary = child.summary()
+            for key in summary:
+                summary[key] += child_summary[key]
+        return summary
+
     def str(self, indent: int = 0):
         """Build a detailed string representation of this Diff and its child DiffElements."""
         margin = " " * indent
@@ -296,6 +309,20 @@ class DiffElement:  # pylint: disable=too-many-instance-attributes
                 return True
 
         return False
+
+    def summary(self) -> Mapping[Text, int]:
+        """Build a summary of this DiffElement and its children."""
+        summary = {
+            "create": 0,
+            "update": 0,
+            "delete": 0,
+        }
+        if self.action:
+            summary[self.action] += 1
+        child_summary = self.child_diff.summary()
+        for key in summary:
+            summary[key] += child_summary[key]
+        return summary
 
     def str(self, indent: int = 0):
         """Build a detailed string representation of this DiffElement and its children."""

--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -254,7 +254,7 @@ class DiffElement:  # pylint: disable=too-many-instance-attributes
 
         Returns:
             dict: of the form `{"-": {key1: <value>, key2: ...}, "+": {key1: <value>, key2: ...}}`,
-            where the `"-"` or `"+"` dicts may be empty.
+            where the `"-"` or `"+"` dicts may be absent.
         """
         if self.source_attrs is not None and self.dest_attrs is not None:
             return {
@@ -270,10 +270,10 @@ class DiffElement:  # pylint: disable=too-many-instance-attributes
                 },
             }
         if self.source_attrs is None and self.dest_attrs is not None:
-            return {"-": {key: self.dest_attrs[key] for key in self.get_attrs_keys()}, "+": {}}
+            return {"-": {key: self.dest_attrs[key] for key in self.get_attrs_keys()}}
         if self.source_attrs is not None and self.dest_attrs is None:
-            return {"-": {}, "+": {key: self.source_attrs[key] for key in self.get_attrs_keys()}}
-        return {"-": {}, "+": {}}
+            return {"+": {key: self.source_attrs[key] for key in self.get_attrs_keys()}}
+        return {}
 
     def add_child(self, element: "DiffElement"):
         """Attach a child object of type DiffElement.
@@ -352,9 +352,9 @@ class DiffElement:  # pylint: disable=too-many-instance-attributes
         """Build a dictionary representation of this DiffElement and its children."""
         attrs_diffs = self.get_attrs_diffs()
         result = {}
-        if attrs_diffs.get("-"):
+        if "-" in attrs_diffs:
             result["-"] = attrs_diffs["-"]
-        if attrs_diffs.get("+"):
+        if "+" in attrs_diffs:
             result["+"] = attrs_diffs["+"]
         if self.child_diff.has_diffs():
             result.update(self.child_diff.dict())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -391,3 +391,36 @@ def diff_with_children():
     diff.add(address_element)
 
     return diff
+
+
+@pytest.fixture()
+def diff_element_with_children():
+    """Construct a DiffElement that has some diffs of its own as well as a child diff with additional diffs."""
+    # parent_element has differing "role" attribute, while "location" does not differ
+    parent_element = DiffElement("device", "device1", {"name": "device1"})
+    parent_element.add_attrs(source={"role": "switch", "location": "RTP"}, dest={"role": "router", "location": "RTP"})
+
+    # child_element_1 has differing "description" attribute, while "interface_type" is only present on one side
+    child_element_1 = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
+    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
+    dest_attrs = {"description": "your interface"}
+    child_element_1.add_attrs(source=source_attrs, dest=dest_attrs)
+
+    # child_element_2 only exists on source, and has no attributes
+    child_element_2 = DiffElement("interface", "lo0", {"device_name": "device1", "name": "lo0"})
+    child_element_2.add_attrs(source={})
+
+    # child_element_3 only exists on dest, and has some attributes
+    child_element_3 = DiffElement("interface", "lo1", {"device_name": "device1", "name": "lo1"})
+    child_element_3.add_attrs(dest={"description": "Loopback 1"})
+
+    # child_element_4 is identical between source and dest
+    child_element_4 = DiffElement("interface", "lo100", {"device_name": "device1", "name": "lo100"})
+    child_element_4.add_attrs(source={"description": "Loopback 100"}, dest={"description": "Loopback 100"})
+
+    parent_element.add_child(child_element_1)
+    parent_element.add_child(child_element_2)
+    parent_element.add_child(child_element_3)
+    parent_element.add_child(child_element_4)
+
+    return parent_element

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,7 +19,7 @@ from typing import ClassVar, List, Mapping, Optional, Tuple
 import pytest
 
 from diffsync import DiffSync, DiffSyncModel
-from diffsync.diff import Diff
+from diffsync.diff import Diff, DiffElement
 from diffsync.exceptions import ObjectNotCreated, ObjectNotUpdated, ObjectNotDeleted
 
 
@@ -357,3 +357,37 @@ class TrackedDiff(Diff):
     def complete(self):
         """Function called when the Diff has been fully constructed and populated with data."""
         self.is_complete = True
+
+
+@pytest.fixture
+def diff_with_children():
+    """Provide a Diff which has multiple children, some of which have children of their own."""
+    diff = Diff()
+
+    # person_element_1 only exists in the source
+    person_element_1 = DiffElement("person", "Jimbo", {"name": "Jimbo"})
+    person_element_1.add_attrs(source={})
+    diff.add(person_element_1)
+
+    # person_element_2 only exists in the dest
+    person_element_2 = DiffElement("person", "Sully", {"name": "Sully"})
+    person_element_2.add_attrs(dest={})
+    diff.add(person_element_2)
+
+    # device_element has no diffs of its own, but has a child intf_element
+    device_element = DiffElement("device", "device1", {"name": "device1"})
+    diff.add(device_element)
+
+    # intf_element exists in both source and dest as a child of device_element, and has differing attrs
+    intf_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
+    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
+    dest_attrs = {"description": "your interface"}
+    intf_element.add_attrs(source=source_attrs, dest=dest_attrs)
+    device_element.add_child(intf_element)
+
+    # address_element exists in both source and dest but has no diffs
+    address_element = DiffElement("address", "RTP", {"name": "RTP"})
+    address_element.add_attrs(source={"state": "NC"}, dest={"state": "NC"})
+    diff.add(address_element)
+
+    return diff

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -34,7 +34,7 @@ def test_diff_empty():
 def test_diff_summary_with_no_diffs():
     diff = Diff()
 
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 0}
 
 
 def test_diff_str_with_no_diffs():
@@ -81,7 +81,11 @@ def test_diff_children():
 
 
 def test_diff_summary_with_diffs(diff_with_children):
-    assert diff_with_children.summary() == {"create": 1, "update": 1, "delete": 1}
+    # Create person "Jimbo"
+    # Delete person "Sully"
+    # Update interface "device1_eth0"
+    # No change to address "RTP" and device "device1"
+    assert diff_with_children.summary() == {"create": 1, "update": 1, "delete": 1, "no-change": 2}
 
 
 def test_diff_str_with_diffs(diff_with_children):

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -31,6 +31,12 @@ def test_diff_empty():
     assert list(diff.get_children()) == []
 
 
+def test_diff_summary_with_no_diffs():
+    diff = Diff()
+
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0}
+
+
 def test_diff_str_with_no_diffs():
     diff = Diff()
 
@@ -72,6 +78,10 @@ def test_diff_children():
     intf_element.add_attrs(source=source_attrs, dest=dest_attrs)
 
     assert diff.has_diffs()
+
+
+def test_diff_summary_with_diffs(diff_with_children):
+    assert diff_with_children.summary() == {"create": 1, "update": 1, "delete": 1}
 
 
 def test_diff_str_with_diffs():

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -84,39 +84,32 @@ def test_diff_summary_with_diffs(diff_with_children):
     assert diff_with_children.summary() == {"create": 1, "update": 1, "delete": 1}
 
 
-def test_diff_str_with_diffs():
-    diff = Diff()
-    device_element = DiffElement("device", "device1", {"name": "device1"})
-    diff.add(device_element)
-    intf_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
-    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
-    dest_attrs = {"description": "your interface"}
-    intf_element.add_attrs(source=source_attrs, dest=dest_attrs)
-    diff.add(intf_element)
-
-    # Since device_element has no diffs, we don't have any "device" entry in the diff string:
+def test_diff_str_with_diffs(diff_with_children):
+    # Since the address element has no diffs, we don't have any "address" entry in the diff string:
     assert (
-        diff.str()
+        diff_with_children.str()
         == """\
-interface
-  interface: eth0
-    description    source(my interface)    dest(your interface)\
+person
+  person: Jimbo MISSING in dest
+  person: Sully MISSING in source
+device
+  device: device1
+    interface
+      interface: eth0
+        description    source(my interface)    dest(your interface)\
 """
     )
 
 
-def test_diff_dict_with_diffs():
-    diff = Diff()
-    device_element = DiffElement("device", "device1", {"name": "device1"})
-    diff.add(device_element)
-    intf_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
-    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
-    dest_attrs = {"description": "your interface"}
-    intf_element.add_attrs(source=source_attrs, dest=dest_attrs)
-    diff.add(intf_element)
-
-    assert diff.dict() == {
-        "interface": {"eth0": {"-": {"description": "your interface"}, "+": {"description": "my interface"}}},
+def test_diff_dict_with_diffs(diff_with_children):
+    # Since the address element has no diffs, we don't have any "address" entry in the diff dict:
+    assert diff_with_children.dict() == {
+        "device": {
+            "device1": {
+                "interface": {"eth0": {"+": {"description": "my interface"}, "-": {"description": "your interface"}}}
+            }
+        },
+        "person": {"Jimbo": {"+": {}}, "Sully": {"-": {}}},
     }
 
 

--- a/tests/unit/test_diff_element.py
+++ b/tests/unit/test_diff_element.py
@@ -111,6 +111,14 @@ def test_diff_element_dict_with_diffs():
     assert element.dict() == {"-": {"description": "your interface"}, "+": {"description": "my interface"}}
 
 
+def test_diff_element_dict_with_diffs_no_attrs():
+    element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
+    element.add_attrs(source={})
+    assert element.dict() == {"+": {}}
+    element.add_attrs(dest={})
+    assert element.dict() == {"+": {}, "-": {}}
+
+
 def test_diff_element_children():
     """Test the basic functionality of the DiffElement class when storing and retrieving child elements."""
     child_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
@@ -131,50 +139,32 @@ def test_diff_element_children():
     assert not parent_element.has_diffs(include_children=False)
 
 
-def test_diff_element_summary_with_child_diffs():
-    parent_element = DiffElement("device", "device1", {"name": "device1"})
-    parent_element.add_attrs(source={"role": "switch"}, dest={"role": "router"})
-    child_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
-    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
-    dest_attrs = {"description": "your interface"}
-    child_element.add_attrs(source=source_attrs, dest=dest_attrs)
-    parent_element.add_child(child_element)
-
-    assert parent_element.summary() == {"create": 0, "update": 2, "delete": 0}
+def test_diff_element_summary_with_child_diffs(diff_element_with_children):
+    assert diff_element_with_children.summary() == {"create": 1, "update": 2, "delete": 1}
 
 
-def test_diff_element_str_with_child_diffs():
-    parent_element = DiffElement("device", "device1", {"name": "device1"})
-    parent_element.add_attrs(source={"role": "switch"}, dest={"role": "router"})
-    child_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
-    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
-    dest_attrs = {"description": "your interface"}
-    child_element.add_attrs(source=source_attrs, dest=dest_attrs)
-    parent_element.add_child(child_element)
-
+def test_diff_element_str_with_child_diffs(diff_element_with_children):
     assert (
-        parent_element.str()
+        diff_element_with_children.str()
         == """\
 device: device1
   role    source(switch)    dest(router)
   interface
     interface: eth0
-      description    source(my interface)    dest(your interface)\
+      description    source(my interface)    dest(your interface)
+    interface: lo0 MISSING in dest
+    interface: lo1 MISSING in source\
 """
     )
 
 
-def test_diff_element_dict_with_child_diffs():
-    parent_element = DiffElement("device", "device1", {"name": "device1"})
-    parent_element.add_attrs(source={"role": "switch"}, dest={"role": "router"})
-    child_element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
-    source_attrs = {"interface_type": "ethernet", "description": "my interface"}
-    dest_attrs = {"description": "your interface"}
-    child_element.add_attrs(source=source_attrs, dest=dest_attrs)
-    parent_element.add_child(child_element)
-
-    assert parent_element.dict() == {
+def test_diff_element_dict_with_child_diffs(diff_element_with_children):
+    assert diff_element_with_children.dict() == {
         "-": {"role": "router"},
         "+": {"role": "switch"},
-        "interface": {"eth0": {"-": {"description": "your interface"}, "+": {"description": "my interface"}}},
+        "interface": {
+            "eth0": {"-": {"description": "your interface"}, "+": {"description": "my interface"}},
+            "lo0": {"+": {}},
+            "lo1": {"-": {"description": "Loopback 1"}},
+        },
     }

--- a/tests/unit/test_diff_element.py
+++ b/tests/unit/test_diff_element.py
@@ -44,7 +44,7 @@ def test_diff_element_empty():
 
 def test_diff_element_summary_with_no_diffs():
     element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
-    assert element.summary() == {"create": 0, "update": 0, "delete": 0}
+    assert element.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 1}
 
 
 def test_diff_element_str_with_no_diffs():
@@ -84,9 +84,9 @@ def test_diff_element_attrs():
 def test_diff_element_summary_with_diffs():
     element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
     element.add_attrs(source={"interface_type": "ethernet", "description": "my interface"})
-    assert element.summary() == {"create": 1, "update": 0, "delete": 0}
+    assert element.summary() == {"create": 1, "update": 0, "delete": 0, "no-change": 0}
     element.add_attrs(dest={"description": "your interface"})
-    assert element.summary() == {"create": 0, "update": 1, "delete": 0}
+    assert element.summary() == {"create": 0, "update": 1, "delete": 0, "no-change": 0}
 
 
 def test_diff_element_str_with_diffs():
@@ -140,7 +140,11 @@ def test_diff_element_children():
 
 
 def test_diff_element_summary_with_child_diffs(diff_element_with_children):
-    assert diff_element_with_children.summary() == {"create": 1, "update": 2, "delete": 1}
+    # create interface "lo0"
+    # delete interface "lo1"
+    # update device "device1" and interface "eth0"
+    # no change to interface "lo100"
+    assert diff_element_with_children.summary() == {"create": 1, "update": 2, "delete": 1, "no-change": 1}
 
 
 def test_diff_element_str_with_child_diffs(diff_element_with_children):


### PR DESCRIPTION
Fixes #41. An alternate approach to meeting this requirement that I considered but decided not to implement would be to have a method that could be called to generate logs for each object that a Diff/DiffElement *would* create/update/delete/leave unchanged, parallel to the logs generated during an actual sync by `DiffSync._sync_from_diff_element()`. **I'm open to the argument that it would be worthwhile to implement that option as well - feedback would be appreciated!**

In the process of refactoring some of the unit tests to reduce repetition, I encountered an issue that the `DiffElement.dict()` method return value didn't distinguish between "source and target both exist but have no relevant attributes" and "source and/or target does not exist at all" - both would be the same dict `{"+": {}, "-": {}}`. I've therefore altered the behavior of this method (and the associated `get_attrs_diffs()` method) so that a completely absent source/dest results in the "+" or "-" key being omitted altogether, making the distinction more clear.