### PR TITLE
get_by_uids() should raise ObjectNotFound when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `DiffSync.get_by_uids()` now raises `ObjectNotFound` if any of the provided uids cannot be located.
 - #34 - in diff dicts, change keys `src`/`dst`/`_src`/`_dst` to `-` and `+`
 - #37 - add `sync_complete` callback, triggered on `sync_from` completion with changes.
 - #41 - add `summary` API for Diff and DiffElement objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `DiffSync.get_by_uids()` now raises `ObjectNotFound` if any of the provided uids cannot be located.
+- `DiffSync.get()` raises `ObjectNotFound` or `ValueError` on failure, instead of returning `None`.
 - #34 - in diff dicts, change keys `src`/`dst`/`_src`/`_dst` to `-` and `+`
 - #37 - add `sync_complete` callback, triggered on `sync_from` completion with changes.
 - #41 - add `summary` API for Diff and DiffElement objects.

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -428,6 +428,13 @@ class DiffSync:
                     f'Incorrect field name - {value.__name__} has type name "{value.get_type()}", not "{name}"'
                 )
 
+        for name in cls.top_level:
+            if not hasattr(cls, name):
+                raise AttributeError(f'top_level references attribute "{name}" but it is not a class attribute!')
+            value = getattr(cls, name)
+            if not isclass(value) or not issubclass(value, DiffSyncModel):
+                raise AttributeError(f'top_level references attribute "{name}" but it is not a DiffSyncModel subclass!')
+
     def __str__(self):
         """String representation of a DiffSync."""
         if self.type != self.name:
@@ -455,6 +462,8 @@ class DiffSync:
         margin = " " * indent
         output = ""
         for modelname in self.top_level:
+            if output:
+                output += "\n"
             output += f"{margin}{modelname}"
             models = self.get_all(modelname)
             if not models:

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -688,17 +688,20 @@ class DiffSync:
         Args:
             uids: List of unique id / key identifying object in the database.
             obj: DiffSyncModel class or instance, or modelname string, that defines the type of the objects to retrieve
+
+        Raises:
+            ObjectNotFound: if any of the requested UIDs are not found in the store
         """
         if isinstance(obj, str):
             modelname = obj
         else:
             modelname = obj.get_type()
 
-        # TODO: should this raise an exception if any or all of the uids are not found?
         results = []
         for uid in uids:
-            if uid in self._data[modelname]:
-                results.append(self._data[modelname][uid])
+            if uid not in self._data[modelname]:
+                raise ObjectNotFound(f"{modelname} {uid} not present")
+            results.append(self._data[modelname][uid])
         return results
 
     def add(self, obj: DiffSyncModel):
@@ -735,7 +738,7 @@ class DiffSync:
         uid = obj.get_unique_id()
 
         if uid not in self._data[modelname]:
-            raise ObjectNotFound(f"Object {uid} not present")
+            raise ObjectNotFound(f"{modelname} {uid} not present")
 
         if obj.diffsync is self:
             obj.diffsync = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -140,14 +140,24 @@ def generic_diffsync():
     return DiffSync()
 
 
+class UnusedModel(DiffSyncModel):
+    """Concrete DiffSyncModel subclass that can be referenced as a class attribute but never has any data."""
+
+    _modelname = "unused"
+    _identifiers = ("name",)
+
+    name: str
+
+
 class GenericBackend(DiffSync):
     """An example semi-abstract subclass of DiffSync."""
 
     site = Site  # to be overridden by subclasses
     device = Device
     interface = Interface
+    unused = UnusedModel
 
-    top_level = ["site"]
+    top_level = ["site", "unused"]
 
     DATA: dict = {}
 

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -66,9 +66,13 @@ def test_diffsync_get_all_with_no_data_is_empty_list(generic_diffsync):
     assert list(generic_diffsync.get_all(DiffSyncModel)) == []
 
 
-def test_diffsync_get_by_uids_with_no_data_is_empty_list(generic_diffsync):
-    assert generic_diffsync.get_by_uids(["any", "another"], "anything") == []
-    assert generic_diffsync.get_by_uids(["any", "another"], DiffSyncModel) == []
+def test_diffsync_get_by_uids_with_no_data(generic_diffsync):
+    assert generic_diffsync.get_by_uids([], "anything") == []
+    assert generic_diffsync.get_by_uids([], DiffSyncModel) == []
+    with pytest.raises(ObjectNotFound):
+        generic_diffsync.get_by_uids(["any", "another"], "anything")
+    with pytest.raises(ObjectNotFound):
+        generic_diffsync.get_by_uids(["any", "another"], DiffSyncModel)
 
 
 def test_diffsync_add(generic_diffsync, generic_diffsync_model):
@@ -104,9 +108,11 @@ def test_diffsync_get_by_uids_with_generic_model(generic_diffsync, generic_diffs
     assert generic_diffsync.get_by_uids([""], DiffSyncModel) == [generic_diffsync_model]
     assert generic_diffsync.get_by_uids([""], DiffSyncModel.get_type()) == [generic_diffsync_model]
     # Wrong unique-id - no match
-    assert generic_diffsync.get_by_uids(["myname"], DiffSyncModel) == []
-    # Valid unique-id mixed in with unknown ones - return the successful matches?
-    assert generic_diffsync.get_by_uids(["aname", "", "anothername"], DiffSyncModel) == [generic_diffsync_model]
+    with pytest.raises(ObjectNotFound):
+        generic_diffsync.get_by_uids(["myname"], DiffSyncModel)
+    # Valid unique-id mixed in with unknown ones
+    with pytest.raises(ObjectNotFound):
+        generic_diffsync.get_by_uids(["aname", "", "anothername"], DiffSyncModel)
 
 
 def test_diffsync_remove_with_generic_model(generic_diffsync, generic_diffsync_model):
@@ -117,7 +123,8 @@ def test_diffsync_remove_with_generic_model(generic_diffsync, generic_diffsync_m
 
     assert generic_diffsync.get(DiffSyncModel, "") is None
     assert list(generic_diffsync.get_all(DiffSyncModel)) == []
-    assert generic_diffsync.get_by_uids([""], DiffSyncModel) == []
+    with pytest.raises(ObjectNotFound):
+        generic_diffsync.get_by_uids([""], DiffSyncModel)
 
 
 def test_diffsync_subclass_validation():
@@ -317,8 +324,10 @@ def test_diffsync_sync_from(backend_a, backend_b):
 
     assert backend_a.get_by_uids(["nyc", "sfo"], Site) == [site_nyc_a, site_sfo_a]
     assert backend_a.get_by_uids(["sfo", "nyc"], "site") == [site_sfo_a, site_nyc_a]
-    assert backend_a.get_by_uids(["nyc", "sfo"], Device) == []
-    assert backend_a.get_by_uids(["nyc", "sfo"], "device") == []
+    with pytest.raises(ObjectNotFound):
+        backend_a.get_by_uids(["nyc", "sfo"], Device)
+    with pytest.raises(ObjectNotFound):
+        backend_a.get_by_uids(["nyc", "sfo"], "device")
 
 
 def test_diffsync_subclass_default_name_type(backend_a):

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -132,19 +132,45 @@ def test_diffsync_remove_with_generic_model(generic_diffsync, generic_diffsync_m
         generic_diffsync.get_by_uids([""], DiffSyncModel)
 
 
-def test_diffsync_subclass_validation():
-    """Test the declaration-time checks on a DiffSync subclass."""
+def test_diffsync_subclass_validation_name_mismatch():
     # pylint: disable=unused-variable
     with pytest.raises(AttributeError) as excinfo:
 
         class BadElementName(DiffSync):
-            """Model with a DiffSyncModel attribute whose name does not match the modelname."""
+            """DiffSync with a DiffSyncModel attribute whose name does not match the modelname."""
 
             dev_class = Device  # should be device = Device
 
     assert "Device" in str(excinfo.value)
     assert "device" in str(excinfo.value)
     assert "dev_class" in str(excinfo.value)
+
+
+def test_diffsync_subclass_validation_missing_top_level():
+    with pytest.raises(AttributeError) as excinfo:
+
+        class MissingTopLevel(DiffSync):
+            """DiffSync whose top_level references an attribute that does not exist on the class."""
+
+            top_level = ["missing"]
+
+    assert "top_level" in str(excinfo.value)
+    assert "missing" in str(excinfo.value)
+    assert "is not a class attribute" in str(excinfo.value)
+
+
+def test_diffsync_subclass_validation_top_level_not_diffsyncmodel():
+    with pytest.raises(AttributeError) as excinfo:
+
+        class TopLevelNotDiffSyncModel(DiffSync):
+            """DiffSync whose top_level references an attribute that is not a DiffSyncModel subclass."""
+
+            age = 0
+            top_level = ["age"]
+
+    assert "top_level" in str(excinfo.value)
+    assert "age" in str(excinfo.value)
+    assert "is not a DiffSyncModel" in str(excinfo.value)
 
 
 def test_diffsync_dict_with_data(backend_a):
@@ -250,7 +276,9 @@ site
           interface: rdu-spine2__eth0: {'interface_type': 'ethernet', 'description': 'Interface 0'}
           interface: rdu-spine2__eth1: {'interface_type': 'ethernet', 'description': 'Interface 1'}
     people
-      person: Glenn Matthews: {}"""
+      person: Glenn Matthews: {}
+unused: []\
+"""
     )
 
 

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -89,8 +89,9 @@ def test_diffsync_get_with_generic_model(generic_diffsync, generic_diffsync_mode
     # The generic_diffsync_model has an empty identifier/unique-id
     assert generic_diffsync.get(DiffSyncModel, "") == generic_diffsync_model
     assert generic_diffsync.get(DiffSyncModel.get_type(), "") == generic_diffsync_model
-    # DiffSync doesn't know how to construct a uid str for a "diffsyncmodel"
-    assert generic_diffsync.get(DiffSyncModel.get_type(), {}) is None
+    # DiffSync doesn't know how to construct a uid str for a "diffsyncmodel" (it needs the class or instance, not a str)
+    with pytest.raises(ValueError):
+        generic_diffsync.get(DiffSyncModel.get_type(), {})
     # Wrong object-type - no match
     with pytest.raises(ObjectNotFound):
         generic_diffsync.get("", "")
@@ -147,6 +148,7 @@ def test_diffsync_subclass_validation_name_mismatch():
 
 
 def test_diffsync_subclass_validation_missing_top_level():
+    # pylint: disable=unused-variable
     with pytest.raises(AttributeError) as excinfo:
 
         class MissingTopLevel(DiffSync):
@@ -160,6 +162,7 @@ def test_diffsync_subclass_validation_missing_top_level():
 
 
 def test_diffsync_subclass_validation_top_level_not_diffsyncmodel():
+    # pylint: disable=unused-variable
     with pytest.raises(AttributeError) as excinfo:
 
         class TopLevelNotDiffSyncModel(DiffSync):

--- a/tests/unit/test_diffsync_model.py
+++ b/tests/unit/test_diffsync_model.py
@@ -195,7 +195,7 @@ site: site1: {}
   devices
     device: device1: {'role': 'default'}
       interfaces
-        device1__eth0 (details unavailable)\
+        device1__eth0 (ERROR: details unavailable)\
 """
     )
 


### PR DESCRIPTION
Instead of silently skipping over unmatched uids, `get_by_uids()` now raises an `ObjectNotFound` exception.