### PR TITLE
Model sync status reporting; logging fixes; refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Now requires Pydantic 1.7.2 or later
+
+- Added `set_status()` API so that DiffSyncModel implementations can provide details for create/update/delete logging
 - `DiffSync.get_by_uids()` now raises `ObjectNotFound` if any of the provided uids cannot be located.
 - `DiffSync.get()` raises `ObjectNotFound` or `ValueError` on failure, instead of returning `None`.
 - #34 - in diff dicts, change keys `src`/`dst`/`_src`/`_dst` to `-` and `+`

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -484,6 +484,9 @@ class DiffSync:
     ):
         """Callback triggered after a `sync_from` operation has completed and updated the model data of this instance.
 
+        Note that this callback is **only** triggered if the sync actually resulted in data changes. If there are no
+        detected changes, this callback will **not** be called.
+
         The default implementation does nothing, but a subclass could use this, for example, to perform bulk updates
         to a backend (such as a file) that doesn't readily support incremental updates to individual records.
 

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -24,7 +24,7 @@ import structlog  # type: ignore
 from .diff import Diff
 from .enum import DiffSyncModelFlags, DiffSyncFlags, DiffSyncStatus
 from .exceptions import ObjectAlreadyExists, ObjectStoreWrongType, ObjectNotFound
-from .workers import DiffSyncDiffer, DiffSyncSyncer
+from .helpers import DiffSyncDiffer, DiffSyncSyncer
 
 
 class DiffSyncModel(BaseModel):

--- a/diffsync/enum.py
+++ b/diffsync/enum.py
@@ -1,0 +1,75 @@
+"""DiffSync enums and flags.
+
+Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import enum
+
+
+class DiffSyncModelFlags(enum.Flag):
+    """Flags that can be set on a DiffSyncModel class or instance to affect its usage."""
+
+    NONE = 0
+
+    IGNORE = 0b1
+    """Do not render diffs containing this model; do not make any changes to this model when synchronizing.
+
+    Can be used to indicate a model instance that exists but should not be changed by DiffSync.
+    """
+
+    SKIP_CHILDREN_ON_DELETE = 0b10
+    """When deleting this model, do not recursively delete its children.
+
+    Can be used for the case where deletion of a model results in the automatic deletion of all its children.
+    """
+
+
+class DiffSyncFlags(enum.Flag):
+    """Flags that can be passed to a sync_* or diff_* call to affect its behavior."""
+
+    NONE = 0
+
+    CONTINUE_ON_FAILURE = 0b1
+    """Continue synchronizing even if failures are encountered when syncing individual models."""
+
+    SKIP_UNMATCHED_SRC = 0b10
+    """Ignore objects that only exist in the source/"from" DiffSync when determining diffs and syncing.
+
+    If this flag is set, no new objects will be created in the target/"to" DiffSync.
+    """
+
+    SKIP_UNMATCHED_DST = 0b100
+    """Ignore objects that only exist in the target/"to" DiffSync when determining diffs and syncing.
+
+    If this flag is set, no objects will be deleted from the target/"to" DiffSync.
+    """
+
+    SKIP_UNMATCHED_BOTH = SKIP_UNMATCHED_SRC | SKIP_UNMATCHED_DST
+
+    LOG_UNCHANGED_RECORDS = 0b1000
+    """If this flag is set, a log message will be generated during synchronization for each model, even unchanged ones.
+
+    By default, when this flag is unset, only models that have actual changes to synchronize will be logged.
+    This flag is off by default to reduce the default verbosity of DiffSync, but can be enabled when debugging.
+    """
+
+
+class DiffSyncStatus(enum.Enum):
+    """Flag values to set as a DiffSyncModel's `_status` when performing a sync; values are logged by DiffSyncSyncer."""
+
+    UNKNOWN = "unknown"
+    SUCCESS = "success"
+    FAILURE = "failure"
+    ERROR = "error"

--- a/diffsync/helpers.py
+++ b/diffsync/helpers.py
@@ -1,4 +1,4 @@
-"""DiffSync worker classes for diff and sync operations.
+"""DiffSync helper classes for calculating and performing diff and sync operations.
 
 Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
 

--- a/diffsync/workers.py
+++ b/diffsync/workers.py
@@ -1,0 +1,361 @@
+"""DiffSync worker classes for diff and sync operations.
+
+Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from collections.abc import Iterable as ABCIterable, Mapping as ABCMapping
+from typing import Iterable, List, Mapping, Optional, Tuple, Type, TYPE_CHECKING
+
+import structlog  # type: ignore
+
+from .diff import Diff, DiffElement
+from .enum import DiffSyncModelFlags, DiffSyncFlags, DiffSyncStatus
+from .exceptions import ObjectNotFound, ObjectNotCreated, ObjectNotUpdated, ObjectNotDeleted, ObjectCrudException
+from .utils import intersection
+
+if TYPE_CHECKING:  # pragma: no cover
+    # For type annotation purposes, we have a circular import loop between __init__.py and this file.
+    from . import DiffSync, DiffSyncModel  # pylint: disable=cyclic-import
+
+
+class DiffSyncDiffer:
+    """Helper class implementing diff calculation logic for DiffSync.
+
+    Independent from Diff and DiffElement as those classes are purely data objects, while this stores some state.
+    """
+
+    def __init__(
+        self, src_diffsync: "DiffSync", dst_diffsync: "DiffSync", flags: DiffSyncFlags, diff_class: Type[Diff] = Diff
+    ):
+        """Create a DiffSyncDiffer for calculating diffs between the provided DiffSync instances."""
+        self.src_diffsync = src_diffsync
+        self.dst_diffsync = dst_diffsync
+        self.flags = flags
+
+        self.logger = structlog.get_logger().new(src=src_diffsync, dst=dst_diffsync, flags=flags)
+        self.diff_class = diff_class
+        self.diff: Optional[Diff] = None
+
+    def calculate_diffs(self) -> Diff:
+        """Calculate diffs between the src and dst DiffSync objects and return the resulting Diff."""
+        if self.diff is not None:
+            return self.diff
+
+        self.logger.info("Beginning diff calculation")
+        self.diff = self.diff_class()
+        for obj_type in intersection(self.dst_diffsync.top_level, self.src_diffsync.top_level):
+            diff_elements = self.diff_object_list(
+                src=self.src_diffsync.get_all(obj_type), dst=self.dst_diffsync.get_all(obj_type),
+            )
+
+            for diff_element in diff_elements:
+                self.diff.add(diff_element)
+
+        self.logger.info("Diff calculation complete")
+        self.diff.complete()
+        return self.diff
+
+    def diff_object_list(self, src: Iterable["DiffSyncModel"], dst: Iterable["DiffSyncModel"]) -> List[DiffElement]:
+        """Calculate diffs between two lists of like objects.
+
+        Helper method to `calculate_diffs`, usually doesn't need to be called directly.
+
+        These helper methods work in a recursive cycle:
+        diff_object_list -> diff_object_pair -> diff_child_objects -> diff_object_list -> etc.
+        """
+        diff_elements = []
+
+        if isinstance(src, ABCIterable) and isinstance(dst, ABCIterable):
+            # Convert a list of DiffSyncModels into a dict using the unique_ids as keys
+            dict_src = {item.get_unique_id(): item for item in src} if not isinstance(src, ABCMapping) else src
+            dict_dst = {item.get_unique_id(): item for item in dst} if not isinstance(dst, ABCMapping) else dst
+
+            combined_dict = {}
+            for uid in dict_src:
+                combined_dict[uid] = (dict_src.get(uid), dict_dst.get(uid))
+            for uid in dict_dst:
+                combined_dict[uid] = (dict_src.get(uid), dict_dst.get(uid))
+        else:
+            # In the future we might support set, etc...
+            raise TypeError(f"Type combination {type(src)}/{type(dst)} is not supported... for now")
+
+        self.validate_objects_for_diff(combined_dict.values())
+
+        for uid in combined_dict:
+            src_obj, dst_obj = combined_dict[uid]
+            diff_element = self.diff_object_pair(src_obj, dst_obj)
+
+            if diff_element:
+                diff_elements.append(diff_element)
+
+        return diff_elements
+
+    @staticmethod
+    def validate_objects_for_diff(object_pairs: Iterable[Tuple[Optional["DiffSyncModel"], Optional["DiffSyncModel"]]]):
+        """Check whether all DiffSyncModels in the given dictionary are valid for comparison to one another.
+
+        Helper method for `diff_object_list`.
+
+        Raises:
+            TypeError: If any pair of objects in the dict have differing get_type() values.
+            ValueError: If any pair of objects in the dict have differing get_shortname() or get_identifiers() values.
+        """
+        for src_obj, dst_obj in object_pairs:
+            # TODO: should we check/enforce whether all source models have the same DiffSync, whether all dest likewise?
+            # TODO: should we check/enforce whether ALL DiffSyncModels in this dict have the same get_type() output?
+            if src_obj and dst_obj:
+                if src_obj.get_type() != dst_obj.get_type():
+                    raise TypeError(f"Type mismatch: {src_obj.get_type()} vs {dst_obj.get_type()}")
+                if src_obj.get_shortname() != dst_obj.get_shortname():
+                    raise ValueError(f"Shortname mismatch: {src_obj.get_shortname()} vs {dst_obj.get_shortname()}")
+                if src_obj.get_identifiers() != dst_obj.get_identifiers():
+                    raise ValueError(f"Keys mismatch: {src_obj.get_identifiers()} vs {dst_obj.get_identifiers()}")
+
+    def diff_object_pair(
+        self, src_obj: Optional["DiffSyncModel"], dst_obj: Optional["DiffSyncModel"]
+    ) -> Optional[DiffElement]:
+        """Diff the two provided DiffSyncModel objects and return a DiffElement or None.
+
+        Helper method to `calculate_diffs`, usually doesn't need to be called directly.
+
+        These helper methods work in a recursive cycle:
+        diff_object_list -> diff_object_pair -> diff_child_objects -> diff_object_list -> etc.
+        """
+        if src_obj:
+            model = src_obj.get_type()
+            unique_id = src_obj.get_unique_id()
+            shortname = src_obj.get_shortname()
+            keys = src_obj.get_identifiers()
+        elif dst_obj:
+            model = dst_obj.get_type()
+            unique_id = dst_obj.get_unique_id()
+            shortname = dst_obj.get_shortname()
+            keys = dst_obj.get_identifiers()
+        else:
+            raise RuntimeError("diff_object_pair() called with neither src_obj nor dst_obj??")
+
+        log = self.logger.bind(model=model, unique_id=unique_id)
+        if self.flags & DiffSyncFlags.SKIP_UNMATCHED_SRC and not dst_obj:
+            log.debug("Skipping unmatched source object")
+            return None
+        if self.flags & DiffSyncFlags.SKIP_UNMATCHED_DST and not src_obj:
+            log.debug("Skipping unmatched dest object")
+            return None
+        if src_obj and src_obj.model_flags & DiffSyncModelFlags.IGNORE:
+            log.debug("Skipping due to IGNORE flag on source object")
+            return None
+        if dst_obj and dst_obj.model_flags & DiffSyncModelFlags.IGNORE:
+            log.debug("Skipping due to IGNORE flag on dest object")
+            return None
+
+        diff_element = DiffElement(
+            obj_type=model,
+            name=shortname,
+            keys=keys,
+            source_name=self.src_diffsync.name,
+            dest_name=self.dst_diffsync.name,
+            diff_class=self.diff_class,
+        )
+
+        if src_obj:
+            diff_element.add_attrs(source=src_obj.get_attrs(), dest=None)
+        if dst_obj:
+            diff_element.add_attrs(source=None, dest=dst_obj.get_attrs())
+
+        # Recursively diff the children of src_obj and dst_obj and attach the resulting diffs to the diff_element
+        self.diff_child_objects(diff_element, src_obj, dst_obj)
+
+        return diff_element
+
+    def diff_child_objects(
+        self, diff_element: DiffElement, src_obj: Optional["DiffSyncModel"], dst_obj: Optional["DiffSyncModel"],
+    ):
+        """For all children of the given DiffSyncModel pair, diff recursively, adding diffs to the given diff_element.
+
+        Helper method to `calculate_diffs`, usually doesn't need to be called directly.
+
+        These helper methods work in a recursive cycle:
+        diff_object_list -> diff_object_pair -> diff_child_objects -> diff_object_list -> etc.
+        """
+        children_mapping: Mapping[str, str]
+        if src_obj and dst_obj:
+            # Get the subset of child types common to both src_obj and dst_obj
+            src_mapping = src_obj.get_children_mapping()
+            dst_mapping = dst_obj.get_children_mapping()
+            children_mapping = {}
+            for child_type, child_fieldname in src_mapping.items():
+                if child_type in dst_mapping:
+                    children_mapping[child_type] = child_fieldname
+        elif src_obj:
+            children_mapping = src_obj.get_children_mapping()
+        elif dst_obj:
+            children_mapping = dst_obj.get_children_mapping()
+        else:
+            raise RuntimeError("Called with neither src_obj nor dest_obj??")
+
+        for child_type, child_fieldname in children_mapping.items():
+            # for example, child_type == "device" and child_fieldname == "devices"
+
+            # for example, getattr(src_obj, "devices") --> list of device uids
+            #          --> src_diffsync.get_by_uids(<list of device uids>, "device") --> list of device instances
+            src_objs = self.src_diffsync.get_by_uids(getattr(src_obj, child_fieldname), child_type) if src_obj else []
+            dst_objs = self.dst_diffsync.get_by_uids(getattr(dst_obj, child_fieldname), child_type) if dst_obj else []
+
+            for child_diff_element in self.diff_object_list(src=src_objs, dst=dst_objs):
+                diff_element.add_child(child_diff_element)
+
+        return diff_element
+
+
+class DiffSyncSyncer:
+    """Helper class implementing data synchronization logic for DiffSync.
+
+    Independent from DiffSync and DiffSyncModel as those classes are purely data objects, while this stores some state.
+    """
+
+    def __init__(
+        self, diff: Diff, src_diffsync: "DiffSync", dst_diffsync: "DiffSync", flags: DiffSyncFlags,
+    ):
+        """Create a DiffSyncSyncer instance, ready to call `perform_sync()` against."""
+        self.diff = diff
+        self.dst_diffsync = dst_diffsync
+        self.flags = flags
+
+        self.base_logger = structlog.get_logger().new(src=src_diffsync, dst=dst_diffsync, flags=flags)
+
+        # Local state maintained during synchronization
+        self.logger: structlog.BoundLogger = self.base_logger
+        self.model_class: Type["DiffSyncModel"]
+        self.action: Optional[str] = None
+
+    def perform_sync(self) -> bool:
+        """Perform data synchronization based on the provided diff."""
+        if not self.diff.has_diffs():
+            self.base_logger.info("No changes to synchronize")
+            return False
+
+        self.base_logger.info("Beginning sync")
+        for element in self.diff.get_children():
+            self.sync_diff_element(element)
+        self.base_logger.info("Sync complete")
+        return True
+
+    def sync_diff_element(self, element: DiffElement, parent_model: "DiffSyncModel" = None):
+        """Recursively synchronize the given DiffElement and its children, if any, into the dst_diffsync.
+
+        Helper method to `perform_sync`.
+        """
+        self.model_class = getattr(self.dst_diffsync, element.type)
+        diffs = element.get_attrs_diffs()
+        self.logger = self.base_logger.bind(
+            action=element.action,
+            model=element.type,
+            unique_id=self.model_class.create_unique_id(**element.keys),
+            diffs=diffs,
+        )
+        self.action = element.action
+        ids = element.keys
+        # We only actually need the "new" attrs to perform a create/update operation, and don't need any for a delete
+        attrs = diffs.get("+", {})
+
+        model: Optional["DiffSyncModel"]
+        try:
+            model = self.dst_diffsync.get(self.model_class, ids)
+            model.set_status(DiffSyncStatus.UNKNOWN)
+        except ObjectNotFound:
+            model = None
+
+        modified_model = self.sync_model(model, ids, attrs)
+        model = modified_model or model
+
+        if not modified_model or not model:
+            self.logger.warning("No object resulted from sync, will not process child objects.")
+            return
+
+        if self.action == "create":
+            if parent_model:
+                parent_model.add_child(model)
+            self.dst_diffsync.add(model)
+        elif self.action == "delete":
+            if parent_model:
+                parent_model.remove_child(model)
+            if model.model_flags & DiffSyncModelFlags.SKIP_CHILDREN_ON_DELETE:
+                # We don't need to process the child objects, but we do need to discard them from the dst_diffsync
+                self.dst_diffsync.remove(model, remove_children=True)
+                return
+            self.dst_diffsync.remove(model)
+
+        for child in element.get_children():
+            self.sync_diff_element(child, parent_model=model)
+
+    def sync_model(self, model: Optional["DiffSyncModel"], ids: Mapping, attrs: Mapping) -> Optional["DiffSyncModel"]:
+        """Create/update/delete the current DiffSyncModel with current ids/attrs, and update self.status and self.message.
+
+        Helper method to `sync_diff_element`.
+        """
+        if self.action is None:
+            status = DiffSyncStatus.SUCCESS
+            message = "No changes to apply; no action needed"
+            self.log_sync_status(self.action, status, message)
+            return model
+
+        try:
+            self.logger.debug(f"Attempting model {self.action}")
+            if self.action == "create":
+                if model is not None:
+                    raise ObjectNotCreated(f"Failed to create {self.model_class.get_type()} {ids} - it already exists!")
+                model = self.model_class.create(diffsync=self.dst_diffsync, ids=ids, attrs=attrs)
+            elif self.action == "update":
+                if model is None:
+                    raise ObjectNotUpdated(f"Failed to update {self.model_class.get_type()} {ids} - not found!")
+                model = model.update(attrs=attrs)
+            elif self.action == "delete":
+                if model is None:
+                    raise ObjectNotDeleted(f"Failed to delete {self.model_class.get_type()} {ids} - not found!")
+                model = model.delete()
+            else:
+                raise ObjectCrudException(f'Unknown action "{self.action}"!')
+
+            if model is not None:
+                status, message = model.get_status()
+            else:
+                status = DiffSyncStatus.FAILURE
+                message = f"{self.model_class.get_type()} {self.action} did not return the model object."
+
+        except ObjectCrudException as exception:
+            status = DiffSyncStatus.ERROR
+            message = str(exception)
+            self.log_sync_status(self.action, status, message)
+            if self.flags & DiffSyncFlags.CONTINUE_ON_FAILURE:
+                return None
+            raise
+
+        self.log_sync_status(self.action, status, message)
+
+        return model
+
+    def log_sync_status(self, action: Optional[str], status: DiffSyncStatus, message: str):
+        """Log the current sync status at the appropriate verbosity with appropriate context.
+
+        Helper method to `sync_diff_element`/`sync_model`.
+        """
+        if action is None:
+            if self.flags & DiffSyncFlags.LOG_UNCHANGED_RECORDS:
+                self.logger.debug(message, status=status.value)
+        elif status == DiffSyncStatus.SUCCESS:
+            self.logger.info(message, status=status.value)
+        elif status == DiffSyncStatus.FAILURE:
+            self.logger.warning(message, status=status.value)
+        else:
+            self.logger.error(message, status=status.value)

--- a/poetry.lock
+++ b/poetry.lock
@@ -137,6 +137,11 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 version = "5.3"
 
+[package.dependencies]
+[package.dependencies.toml]
+optional = true
+version = "*"
+
 [package.extras]
 toml = ["toml"]
 
@@ -761,7 +766,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "b3b6a297bc2bcb6bbf556d20435f359d93447627c47488dc8dae11b7c9d56964"
+content-hash = "3add6477a36bf30d25671820ebc294e3ab320bb9de9033ed219c87afa5d1f50f"
 python-versions = "^3.7"
 
 [metadata.files]

--- a/poetry.lock
+++ b/poetry.lock
@@ -452,7 +452,7 @@ description = "Data validation and settings management using python 3.6 type hin
 name = "pydantic"
 optional = false
 python-versions = ">=3.6"
-version = "1.6.1"
+version = "1.7.2"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -761,7 +761,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "df11dba646e7bbc5b3c4379563d115085f6e12a0438db1397b17d0782e4bfe37"
+content-hash = "b3b6a297bc2bcb6bbf556d20435f359d93447627c47488dc8dae11b7c9d56964"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -990,23 +990,28 @@ pycodestyle = [
     {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
 ]
 pydantic = [
-    {file = "pydantic-1.6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:418b84654b60e44c0cdd5384294b0e4bc1ebf42d6e873819424f3b78b8690614"},
-    {file = "pydantic-1.6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4900b8820b687c9a3ed753684337979574df20e6ebe4227381d04b3c3c628f99"},
-    {file = "pydantic-1.6.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:b49c86aecde15cde33835d5d6360e55f5e0067bb7143a8303bf03b872935c75b"},
-    {file = "pydantic-1.6.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2de562a456c4ecdc80cf1a8c3e70c666625f7d02d89a6174ecf63754c734592e"},
-    {file = "pydantic-1.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f769141ab0abfadf3305d4fcf36660e5cf568a666dd3efab7c3d4782f70946b1"},
-    {file = "pydantic-1.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2dc946b07cf24bee4737ced0ae77e2ea6bc97489ba5a035b603bd1b40ad81f7e"},
-    {file = "pydantic-1.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:36dbf6f1be212ab37b5fda07667461a9219c956181aa5570a00edfb0acdfe4a1"},
-    {file = "pydantic-1.6.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:1783c1d927f9e1366e0e0609ae324039b2479a1a282a98ed6a6836c9ed02002c"},
-    {file = "pydantic-1.6.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:cf3933c98cb5e808b62fae509f74f209730b180b1e3c3954ee3f7949e083a7df"},
-    {file = "pydantic-1.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f8af9b840a9074e08c0e6dc93101de84ba95df89b267bf7151d74c553d66833b"},
-    {file = "pydantic-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:40d765fa2d31d5be8e29c1794657ad46f5ee583a565c83cea56630d3ae5878b9"},
-    {file = "pydantic-1.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3fa799f3cfff3e5f536cbd389368fc96a44bb30308f258c94ee76b73bd60531d"},
-    {file = "pydantic-1.6.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:6c3f162ba175678218629f446a947e3356415b6b09122dcb364e58c442c645a7"},
-    {file = "pydantic-1.6.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:eb75dc1809875d5738df14b6566ccf9fd9c0bcde4f36b72870f318f16b9f5c20"},
-    {file = "pydantic-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:530d7222a2786a97bc59ee0e0ebbe23728f82974b1f1ad9a11cd966143410633"},
-    {file = "pydantic-1.6.1-py36.py37.py38-none-any.whl", hash = "sha256:b5b3489cb303d0f41ad4a7390cf606a5f2c7a94dcba20c051cd1c653694cb14d"},
-    {file = "pydantic-1.6.1.tar.gz", hash = "sha256:54122a8ed6b75fe1dd80797f8251ad2063ea348a03b77218d73ea9fe19bd4e73"},
+    {file = "pydantic-1.7.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dfaa6ed1d509b5aef4142084206584280bb6e9014f01df931ec6febdad5b200a"},
+    {file = "pydantic-1.7.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:2182ba2a9290964b278bcc07a8d24207de709125d520efec9ad6fa6f92ee058d"},
+    {file = "pydantic-1.7.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:0fe8b45d31ae53d74a6aa0bf801587bd49970070eac6a6326f9fa2a302703b8a"},
+    {file = "pydantic-1.7.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:01f0291f4951580f320f7ae3f2ecaf0044cdebcc9b45c5f882a7e84453362420"},
+    {file = "pydantic-1.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:4ba6b903e1b7bd3eb5df0e78d7364b7e831ed8b4cd781ebc3c4f1077fbcb72a4"},
+    {file = "pydantic-1.7.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b11fc9530bf0698c8014b2bdb3bbc50243e82a7fa2577c8cfba660bcc819e768"},
+    {file = "pydantic-1.7.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a3c274c49930dc047a75ecc865e435f3df89715c775db75ddb0186804d9b04d0"},
+    {file = "pydantic-1.7.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:c68b5edf4da53c98bb1ccb556ae8f655575cb2e676aef066c12b08c724a3f1a1"},
+    {file = "pydantic-1.7.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:95d4410c4e429480c736bba0db6cce5aaa311304aea685ebcf9ee47571bfd7c8"},
+    {file = "pydantic-1.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:a2fc7bf77ed4a7a961d7684afe177ff59971828141e608f142e4af858e07dddc"},
+    {file = "pydantic-1.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9572c0db13c8658b4a4cb705dcaae6983aeb9842248b36761b3fbc9010b740f"},
+    {file = "pydantic-1.7.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f83f679e727742b0c465e7ef992d6da4a7e5268b8edd8fdaf5303276374bef52"},
+    {file = "pydantic-1.7.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:e5fece30e80087d9b7986104e2ac150647ec1658c4789c89893b03b100ca3164"},
+    {file = "pydantic-1.7.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce2d452961352ba229fe1e0b925b41c0c37128f08dddb788d0fd73fd87ea0f66"},
+    {file = "pydantic-1.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:fc21a37ff3f545de80b166e1735c4172b41b017948a3fb2d5e2f03c219eac50a"},
+    {file = "pydantic-1.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c9760d1556ec59ff745f88269a8f357e2b7afc75c556b3a87b8dda5bc62da8ba"},
+    {file = "pydantic-1.7.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c1673633ad1eea78b1c5c420a47cd48717d2ef214c8230d96ca2591e9e00958"},
+    {file = "pydantic-1.7.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:388c0c26c574ff49bad7d0fd6ed82fbccd86a0473fa3900397d3354c533d6ebb"},
+    {file = "pydantic-1.7.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ab1d5e4d8de00575957e1c982b951bffaedd3204ddd24694e3baca3332e53a23"},
+    {file = "pydantic-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:f045cf7afb3352a03bc6cb993578a34560ac24c5d004fa33c76efec6ada1361a"},
+    {file = "pydantic-1.7.2-py3-none-any.whl", hash = "sha256:6665f7ab7fbbf4d3c1040925ff4d42d7549a8c15fe041164adfe4fc2134d4cce"},
+    {file = "pydantic-1.7.2.tar.gz", hash = "sha256:c8200aecbd1fb914e1bd061d71a4d1d79ecb553165296af0c14989b89e90d09b"},
 ]
 pydocstyle = [
     {file = "pydocstyle-5.1.1-py3-none-any.whl", hash = "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ ipython = "^7.18.1"
 mypy = "^0.782"
 pytest-cov = "^2.10.1"
 pytest-structlog = "^0.3"
+coverage = {extras = ["toml"], version = "^5.3"}
 
 [tool.black]
 line-length = 120
@@ -50,6 +51,9 @@ exclude = '''
         | dist
         )/
     '''
+
+[tool.coverage.run]
+branch = true
 
 [tool.pylint.general]
 extension-pkg-whitelist = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pydantic = "^1.6.1"
+pydantic = "^1.7.2"
 structlog = "^20.1.0"
 colorama = {version = "^0.4.3", optional = true}
 

--- a/tasks.py
+++ b/tasks.py
@@ -123,7 +123,8 @@ def pytest(context, name=NAME, python_ver=PYTHON_VER):
     # Install python module
     docker = f"docker run -it -v {PWD}:/local {name}-{python_ver}:latest"
     context.run(
-        f"{docker} /bin/bash -c 'poetry install && pytest --cov=diffsync --cov-report html --cov-report term -vv'",
+        f"{docker} /bin/bash -c 'poetry install && pytest "
+        "--cov=diffsync --cov-config pyproject.toml --cov-report html --cov-report term -vv'",
         pty=True,
     )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -29,7 +29,7 @@ def generic_diffsync_model():
     return DiffSyncModel()
 
 
-class ErrorProneModel(DiffSyncModel):
+class ErrorProneModelMixin:
     """Test class that sometimes throws exceptions when creating/updating/deleting instances."""
 
     _counter: ClassVar[int] = 0
@@ -40,7 +40,7 @@ class ErrorProneModel(DiffSyncModel):
         cls._counter += 1
         if not cls._counter % 3:
             raise ObjectNotCreated("Random creation error!")
-        return super().create(diffsync, ids, attrs)
+        return super().create(diffsync, ids, attrs)  # type: ignore
 
     def update(self, attrs: Mapping):
         """As DiffSyncModel.update(), but periodically throw exceptions."""
@@ -48,7 +48,7 @@ class ErrorProneModel(DiffSyncModel):
         self.__class__._counter += 1
         if not self.__class__._counter % 3:
             raise ObjectNotUpdated("Random update error!")
-        return super().update(attrs)
+        return super().update(attrs)  # type: ignore
 
     def delete(self):
         """As DiffSyncModel.delete(), but periodically throw exceptions."""
@@ -56,7 +56,7 @@ class ErrorProneModel(DiffSyncModel):
         self.__class__._counter += 1
         if not self.__class__._counter % 3:
             raise ObjectNotDeleted("Random deletion error!")
-        return super().delete()
+        return super().delete()  # type: ignore
 
 
 class Site(DiffSyncModel):
@@ -266,15 +266,15 @@ def backend_a_minus_some_models():
     return missing_models
 
 
-class ErrorProneSiteA(ErrorProneModel, SiteA):
+class ErrorProneSiteA(ErrorProneModelMixin, SiteA):
     """A Site that sometimes throws exceptions."""
 
 
-class ErrorProneDeviceA(ErrorProneModel, DeviceA):
+class ErrorProneDeviceA(ErrorProneModelMixin, DeviceA):
     """A Device that sometimes throws exceptions."""
 
 
-class ErrorProneInterface(ErrorProneModel, Interface):
+class ErrorProneInterface(ErrorProneModelMixin, Interface):
     """An Interface that sometimes throws exceptions."""
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,24 +38,30 @@ class ErrorProneModelMixin:
     def create(cls, diffsync: DiffSync, ids: Mapping, attrs: Mapping):
         """As DiffSyncModel.create(), but periodically throw exceptions."""
         cls._counter += 1
-        if not cls._counter % 3:
+        if not cls._counter % 5:
             raise ObjectNotCreated("Random creation error!")
+        if not cls._counter % 4:
+            return None  # non-fatal error
         return super().create(diffsync, ids, attrs)  # type: ignore
 
     def update(self, attrs: Mapping):
         """As DiffSyncModel.update(), but periodically throw exceptions."""
         # pylint: disable=protected-access
         self.__class__._counter += 1
-        if not self.__class__._counter % 3:
+        if not self.__class__._counter % 5:
             raise ObjectNotUpdated("Random update error!")
+        if not self.__class__._counter % 4:
+            return None  # non-fatal error
         return super().update(attrs)  # type: ignore
 
     def delete(self):
         """As DiffSyncModel.delete(), but periodically throw exceptions."""
         # pylint: disable=protected-access
         self.__class__._counter += 1
-        if not self.__class__._counter % 3:
+        if not self.__class__._counter % 5:
             raise ObjectNotDeleted("Random deletion error!")
+        if not self.__class__._counter % 4:
+            return None  # non-fatal error
         return super().delete()  # type: ignore
 
 

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -368,6 +368,105 @@ def test_diffsync_sync_from(backend_a, backend_b):
         backend_a.get_by_uids(["nyc", "sfo"], "device")
 
 
+def check_sync_logs_against_diff(diffsync, diff, log, errors_permitted=False):
+    """Given a Diff, make sure the captured structlogs correctly correspond to its contents/actions."""
+    for element in diff.get_children():
+        print(element)
+        # This is kinda gross, but needed since a DiffElement stores a shortname and keys, not a unique_id
+        uid = getattr(diffsync, element.type).create_unique_id(**element.keys)
+
+        elem_events = [
+            event for event in log.events if event.get("model") == element.type and event.get("unique_id") == uid
+        ]
+        assert elem_events, f"No events for {element.type} {uid} in:\n{log.events}"
+        num_events = len(elem_events)
+
+        if element.action is None:
+            assert num_events == 1, f"Wrong number of events for {element}: {elem_events}"
+            assert {
+                ("action", None),
+                ("event", "No changes to apply; no action needed"),
+                ("level", "debug"),
+            } <= elem_events[0].items()
+        else:
+            # In case of an error, there will be a third log, warning that child elements will not be synced
+            if errors_permitted:
+                assert num_events in (2, 3), f"Wrong number of events for {element}: {elem_events}"
+            else:
+                assert num_events == 2, f"Wrong number of events for {element}: {elem_events}"
+            begin_event, complete_event = elem_events[:2]
+
+            assert {
+                ("action", element.action),
+                ("event", f"Attempting model {element.action}"),
+                ("level", "debug"),
+            } <= begin_event.items()
+            # attrs_diffs dict is unhashable so we can't include it in the above set comparison
+            assert "diffs" in begin_event and begin_event["diffs"] == element.get_attrs_diffs()
+            assert "status" not in begin_event
+
+            if not errors_permitted:
+                assert complete_event["level"] == "info" and complete_event["status"] == "success", complete_event
+
+            if complete_event["status"] == "success":
+                assert {
+                    ("action", element.action),
+                    ("event", f"{element.action.title()}d successfully"),
+                    ("level", "info"),
+                    ("status", "success"),
+                } <= complete_event.items()
+            elif complete_event["status"] == "failure":
+                assert {
+                    ("action", element.action),
+                    ("level", "warning"),
+                    ("status", "failure"),
+                } <= complete_event.items()
+            else:
+                assert {("action", element.action), ("level", "error"), ("status", "error")} <= complete_event.items()
+
+            # attrs_diffs dict is unhashable so we can't include it in the above set comparison
+            assert "diffs" in complete_event and complete_event["diffs"] == element.get_attrs_diffs()
+
+            if num_events == 3:
+                child_skip_warning = elem_events[-1]
+                assert {
+                    ("action", element.action),
+                    ("event", "No object resulted from sync, will not process child objects."),
+                    ("level", "warning"),
+                } <= child_skip_warning.items()
+                assert "status" not in child_skip_warning
+
+        # Recurse into child diff if applicable
+        if num_events < 3:  # i.e., no error happened
+            check_sync_logs_against_diff(diffsync, element.child_diff, log, errors_permitted)
+
+
+def test_diffsync_sync_from_successful_logging(log, backend_a, backend_b):
+    diff = backend_a.diff_from(backend_b)
+    # Discard logs generated during diff calculation
+    log.events = []
+
+    backend_a.sync_from(backend_b, flags=DiffSyncFlags.LOG_UNCHANGED_RECORDS)
+
+    # All logs generated during the sync should include the src, dst, and flags data
+    for event in log.events:
+        assert "src" in event and event["src"] == backend_b
+        assert "dst" in event and event["dst"] == backend_a
+        assert "flags" in event and event["flags"] == DiffSyncFlags.LOG_UNCHANGED_RECORDS
+
+    # No warnings or errors should have been logged in a fully successful sync
+    assert all(event["level"] == "debug" or event["level"] == "info" for event in log.events)
+
+    # Logs for beginning and end of diff and sync should have been generated
+    assert log.has("Beginning diff calculation", level="info")
+    assert log.has("Diff calculation complete", level="info")
+    assert log.has("Beginning sync", level="info")
+    assert log.has("Sync complete", level="info")
+
+    # Make sure logs were accurately generated
+    check_sync_logs_against_diff(backend_a, diff, log)
+
+
 def test_diffsync_subclass_default_name_type(backend_a):
     assert backend_a.name == "BackendA"
     assert backend_a.type == "BackendA"
@@ -419,7 +518,12 @@ def test_diffsync_sync_from_exceptions_are_not_caught_by_default(error_prone_bac
 
 
 def test_diffsync_sync_from_with_continue_on_failure_flag(log, error_prone_backend_a, backend_b):
-    error_prone_backend_a.sync_from(backend_b, flags=DiffSyncFlags.CONTINUE_ON_FAILURE)
+    base_diffs = error_prone_backend_a.diff_from(backend_b)
+    log.events = []
+
+    error_prone_backend_a.sync_from(
+        backend_b, flags=DiffSyncFlags.CONTINUE_ON_FAILURE | DiffSyncFlags.LOG_UNCHANGED_RECORDS
+    )
     # Not all sync operations succeeded on the first try
     remaining_diffs = error_prone_backend_a.diff_from(backend_b)
     print(remaining_diffs.str())  # for debugging of any failure
@@ -433,6 +537,9 @@ def test_diffsync_sync_from_with_continue_on_failure_flag(log, error_prone_backe
     assert [event for event in log.events if event["level"] == "error"] != []
     # Some messages with status="error" should have been logged - these may be the same as the above
     assert [event for event in log.events if event.get("status") == "error"] != []
+
+    check_sync_logs_against_diff(error_prone_backend_a, base_diffs, log, errors_permitted=True)
+
     log.events = []
 
     # Retry up to 10 times, we should sync successfully eventually


### PR DESCRIPTION
A bit of a grab-bag here, my apologies!

- `DiffSyncModel`s now have `set_status` and `get_status` APIs, with the idea being that a model's `create`/`update`/`delete` method can use `set_status` to report statuses and messages other than the default, generic `(SUCCESS, "Created successfully")`. 
  - This is sort of a sideways approach to #35, as while it doesn't provide any automatic validation of whether a sync actually updated the backend, an implementer can now at least start with boilerplate CRUD functions that do something like `set_status(FAILED, "backend sync not implemented yet")` as a reminder to the implementer/user.
- This necessitated updating our minimum Pydantic version from 1.6 to 1.7 to pick up support for `PrivateAttr` attributes on a DiffSyncModel.
- In updating the sync logging logic to account for a model's reported status, I discovered a bug -- if a CRUD method fails gracefully (i.e. returns `None` instead of throwing an `ObjectCrudException`), we would get a log message for the failure *but also* still get a "success" log for that object as well. I've added test coverage in `test_diffsync.py` to catch this bug and ones like it.
- The updated logging logic pushed `__init__.py` over the arbitrary 1000-line limit imposed by pylint, which was already also complaining about the complexity of the `_sync_from_diff_element` function and the number of arguments being passed around between private sync helper functions. I got carried away somewhat and:
  - Similar to what was done in #20 to extract diff calculation logic into a `DiffSyncDiffer` stateful helper class, I've extracted the sync logic out of `DiffSync` and into a stateful `DiffSyncSyncer` helper class. Having some internal state in `DiffSyncSyncer` allowed me to reduce the number of parameters being passed around between internal methods and generally make the logic a bit cleaner.
  - To address the 1000-line module complaint, I moved the enums and flags into a `diffsync.enum` submodule, and moved `DiffSyncDiffer` and `DiffSyncSyncer` into a `diffsync.workers` submodule.  