### PR TITLE
Add progress callback and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ A.sync_from(B)
 A.sync_to(B)
 ```
 
+You may wish to peruse the [`diffsync` GitHub topic](https://github.com/topics/diffsync) for examples of projects using this library.
+
 # Getting started
 
-To be able to properly compare different datasets, DiffSync relies on a shared datamodel that both systems must use.
+To be able to properly compare different datasets, DiffSync relies on a shared data model that both systems must use.
 Specifically, each system or dataset must provide a `DiffSync` "adapter" subclass, which in turn represents its dataset as instances of one or more `DiffSyncModel` data model classes.
 
 When comparing two systems, DiffSync detects the intersection between the two systems (which data models they have in common, and which attributes are shared between each pair of data models) and uses this intersection to compare and/or synchronize the data.
@@ -39,9 +41,9 @@ Each `DiffSyncModel` subclass supports the following class-level attributes:
 - `_attributes` - List of non-identifier instance field names for this object; used to identify the fields in common between data models for different systems (Optional)
 - `_children` - Dict of `{<model_name>: <field_name>}` indicating which fields store references to child data model instances. (Optional)
 
-> DiffSyncModel instances must be uniquely identified by their unique id, composed of all fields defined in `_identifiers`. The unique id must be globally meaningful (such as an unique instance name or slug), as it is used to identify object correspondence between differing systems or data sets. It **must not** be a value that is only locally meaningful, such as a database primary key integer value.
+> DiffSyncModel instances must be uniquely identified by their unique ID (or, in database terminology, [natural key](https://en.wikipedia.org/wiki/Natural_key)), which is composed of the union of all fields defined in `_identifiers`. The unique ID must be globally meaningful (such as an unique instance name or slug), as it is used to identify object correspondence between differing systems or data sets. It **must not** be a value that is only locally meaningful to a specific data set, such as a database primary key value.
 
-> Only fields listed in `_identifiers`, `_attributes`, or `_children` will be potentially included in comparison and synchronization between systems or data sets. Any other fields will be ignored; this allows for a model to additionally contain fields that are only locally relevant (such as database primary key values) and therefore are irrelevant to comparisons.
+> Only fields listed in `_identifiers`, `_attributes`, or `_children` will be potentially included in comparison and synchronization between systems or data sets. Any other fields will be ignored; this allows for a model to additionally contain fields that are only locally relevant (such as database primary key values) and therefore are irrelevant to comparison and synchronization.
 
 ```python
 from typing import List, Optional

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -460,7 +460,7 @@ class DiffSync:
         source: "DiffSync",
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
-        callback: Optional[Callable[[int, int], None]] = None,
+        callback: Optional[Callable[[Text, int, int], None]] = None,
     ):
         """Synchronize data from the given source DiffSync object into the current DiffSync object.
 
@@ -468,10 +468,10 @@ class DiffSync:
             source (DiffSync): object to sync data from into this one
             diff_class (class): Diff or subclass thereof to use to calculate the diffs to use for synchronization
             flags (DiffSyncFlags): Flags influencing the behavior of this sync.
-            callback (function): Function with parameters (current, total), to be called at intervals as the
-                calculation of the diff proceeds.
+            callback (function): Function with parameters (stage, current, total), to be called at intervals as the
+                calculation of the diff and subsequent sync proceed.
         """
-        diff = self.diff_from(source, diff_class=diff_class, flags=flags)
+        diff = self.diff_from(source, diff_class=diff_class, flags=flags, callback=callback)
         syncer = DiffSyncSyncer(diff=diff, src_diffsync=source, dst_diffsync=self, flags=flags, callback=callback)
         result = syncer.perform_sync()
         if result:
@@ -482,7 +482,7 @@ class DiffSync:
         target: "DiffSync",
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
-        callback: Optional[Callable[[int, int], None]] = None,
+        callback: Optional[Callable[[Text, int, int], None]] = None,
     ):
         """Synchronize data from the current DiffSync object into the given target DiffSync object.
 
@@ -490,8 +490,8 @@ class DiffSync:
             target (DiffSync): object to sync data into from this one.
             diff_class (class): Diff or subclass thereof to use to calculate the diffs to use for synchronization
             flags (DiffSyncFlags): Flags influencing the behavior of this sync.
-            callback (function): Function with parameters (current, total), to be called at intervals as the
-                calculation of the diff proceeds.
+            callback (function): Function with parameters (stage, current, total), to be called at intervals as the
+                calculation of the diff and subsequent sync proceed.
         """
         target.sync_from(self, diff_class=diff_class, flags=flags, callback=callback)
 
@@ -526,7 +526,7 @@ class DiffSync:
         source: "DiffSync",
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
-        callback: Optional[Callable[[int, int], None]] = None,
+        callback: Optional[Callable[[Text, int, int], None]] = None,
     ) -> Diff:
         """Generate a Diff describing the difference from the other DiffSync to this one.
 
@@ -534,7 +534,7 @@ class DiffSync:
             source (DiffSync): Object to diff against.
             diff_class (class): Diff or subclass thereof to use for diff calculation and storage.
             flags (DiffSyncFlags): Flags influencing the behavior of this diff operation.
-            callback (function): Function with parameters (current, total), to be called at intervals as the
+            callback (function): Function with parameters (stage, current, total), to be called at intervals as the
                 calculation of the diff proceeds.
         """
         differ = DiffSyncDiffer(
@@ -547,7 +547,7 @@ class DiffSync:
         target: "DiffSync",
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
-        callback: Optional[Callable[[int, int], None]] = None,
+        callback: Optional[Callable[[Text, int, int], None]] = None,
     ) -> Diff:
         """Generate a Diff describing the difference from this DiffSync to another one.
 
@@ -555,7 +555,7 @@ class DiffSync:
             target (DiffSync): Object to diff against.
             diff_class (class): Diff or subclass thereof to use for diff calculation and storage.
             flags (DiffSyncFlags): Flags influencing the behavior of this diff operation.
-            callback (function): Function with parameters (current, total), to be called at intervals as the
+            callback (function): Function with parameters (stage, current, total), to be called at intervals as the
                 calculation of the diff proceeds.
         """
         return target.diff_from(self, diff_class=diff_class, flags=flags, callback=callback)

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -455,29 +455,45 @@ class DiffSync:
     # Synchronization between DiffSync instances
     # ------------------------------------------------------------------------------
 
-    def sync_from(self, source: "DiffSync", diff_class: Type[Diff] = Diff, flags: DiffSyncFlags = DiffSyncFlags.NONE):
+    def sync_from(
+        self,
+        source: "DiffSync",
+        diff_class: Type[Diff] = Diff,
+        flags: DiffSyncFlags = DiffSyncFlags.NONE,
+        callback: Optional[Callable[[int, int], None]] = None,
+    ):
         """Synchronize data from the given source DiffSync object into the current DiffSync object.
 
         Args:
             source (DiffSync): object to sync data from into this one
             diff_class (class): Diff or subclass thereof to use to calculate the diffs to use for synchronization
             flags (DiffSyncFlags): Flags influencing the behavior of this sync.
+            callback (function): Function with parameters (current, total), to be called at intervals as the
+                calculation of the diff proceeds.
         """
         diff = self.diff_from(source, diff_class=diff_class, flags=flags)
-        syncer = DiffSyncSyncer(diff=diff, src_diffsync=source, dst_diffsync=self, flags=flags)
+        syncer = DiffSyncSyncer(diff=diff, src_diffsync=source, dst_diffsync=self, flags=flags, callback=callback)
         result = syncer.perform_sync()
         if result:
             self.sync_complete(source, diff, flags, syncer.base_logger)
 
-    def sync_to(self, target: "DiffSync", diff_class: Type[Diff] = Diff, flags: DiffSyncFlags = DiffSyncFlags.NONE):
+    def sync_to(
+        self,
+        target: "DiffSync",
+        diff_class: Type[Diff] = Diff,
+        flags: DiffSyncFlags = DiffSyncFlags.NONE,
+        callback: Optional[Callable[[int, int], None]] = None,
+    ):
         """Synchronize data from the current DiffSync object into the given target DiffSync object.
 
         Args:
             target (DiffSync): object to sync data into from this one.
             diff_class (class): Diff or subclass thereof to use to calculate the diffs to use for synchronization
             flags (DiffSyncFlags): Flags influencing the behavior of this sync.
+            callback (function): Function with parameters (current, total), to be called at intervals as the
+                calculation of the diff proceeds.
         """
-        target.sync_from(self, diff_class=diff_class, flags=flags)
+        target.sync_from(self, diff_class=diff_class, flags=flags, callback=callback)
 
     def sync_complete(
         self,

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -1,6 +1,6 @@
 """DiffSync front-end classes and logic.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ limitations under the License.
 """
 from collections import defaultdict
 from inspect import isclass
-from typing import ClassVar, Dict, List, Mapping, MutableMapping, Optional, Text, Tuple, Type, Union
+from typing import Callable, ClassVar, Dict, List, Mapping, MutableMapping, Optional, Text, Tuple, Type, Union
 
 from pydantic import BaseModel, PrivateAttr
 import structlog  # type: ignore
@@ -359,7 +359,7 @@ class DiffSyncModel(BaseModel):
 class DiffSync:
     """Class for storing a group of DiffSyncModel instances and diffing/synchronizing to another DiffSync instance."""
 
-    # Add mapping of names to specific model classes here:
+    # In any subclass, you would add mapping of names to specific model classes here:
     # modelname1 = MyModelClass1
     # modelname2 = MyModelClass2
 
@@ -417,6 +417,10 @@ class DiffSync:
 
     def __repr__(self):
         return f"<{str(self)}>"
+
+    def __len__(self):
+        """Total number of elements stored in self._data."""
+        return sum(len(entries) for entries in self._data.values())
 
     def load(self):
         """Load all desired data from whatever backend data source into this instance."""
@@ -502,7 +506,11 @@ class DiffSync:
     # ------------------------------------------------------------------------------
 
     def diff_from(
-        self, source: "DiffSync", diff_class: Type[Diff] = Diff, flags: DiffSyncFlags = DiffSyncFlags.NONE
+        self,
+        source: "DiffSync",
+        diff_class: Type[Diff] = Diff,
+        flags: DiffSyncFlags = DiffSyncFlags.NONE,
+        callback: Optional[Callable[[int, int], None]] = None,
     ) -> Diff:
         """Generate a Diff describing the difference from the other DiffSync to this one.
 
@@ -510,12 +518,20 @@ class DiffSync:
             source (DiffSync): Object to diff against.
             diff_class (class): Diff or subclass thereof to use for diff calculation and storage.
             flags (DiffSyncFlags): Flags influencing the behavior of this diff operation.
+            callback (function): Function with parameters (current, total), to be called at intervals as the
+                calculation of the diff proceeds.
         """
-        differ = DiffSyncDiffer(src_diffsync=source, dst_diffsync=self, flags=flags, diff_class=diff_class)
+        differ = DiffSyncDiffer(
+            src_diffsync=source, dst_diffsync=self, flags=flags, diff_class=diff_class, callback=callback
+        )
         return differ.calculate_diffs()
 
     def diff_to(
-        self, target: "DiffSync", diff_class: Type[Diff] = Diff, flags: DiffSyncFlags = DiffSyncFlags.NONE
+        self,
+        target: "DiffSync",
+        diff_class: Type[Diff] = Diff,
+        flags: DiffSyncFlags = DiffSyncFlags.NONE,
+        callback: Optional[Callable[[int, int], None]] = None,
     ) -> Diff:
         """Generate a Diff describing the difference from this DiffSync to another one.
 
@@ -523,8 +539,10 @@ class DiffSync:
             target (DiffSync): Object to diff against.
             diff_class (class): Diff or subclass thereof to use for diff calculation and storage.
             flags (DiffSyncFlags): Flags influencing the behavior of this diff operation.
+            callback (function): Function with parameters (current, total), to be called at intervals as the
+                calculation of the diff proceeds.
         """
-        return target.diff_from(self, diff_class=diff_class, flags=flags)
+        return target.diff_from(self, diff_class=diff_class, flags=flags, callback=callback)
 
     # ------------------------------------------------------------------------------
     # Object Storage Management
@@ -567,21 +585,21 @@ class DiffSync:
             raise ObjectNotFound(f"{modelname} {uid} not present in {self.name}")
         return self._data[modelname][uid]
 
-    def get_all(self, obj: Union[Text, DiffSyncModel, Type[DiffSyncModel]]):
+    def get_all(self, obj: Union[Text, DiffSyncModel, Type[DiffSyncModel]]) -> List[DiffSyncModel]:
         """Get all objects of a given type.
 
         Args:
             obj: DiffSyncModel class or instance, or modelname string, that defines the type of the objects to retrieve
 
         Returns:
-            ValuesList[DiffSyncModel]: List of Object
+            List[DiffSyncModel]: List of Object
         """
         if isinstance(obj, str):
             modelname = obj
         else:
             modelname = obj.get_type()
 
-        return self._data[modelname].values()
+        return list(self._data[modelname].values())
 
     def get_by_uids(
         self, uids: List[Text], obj: Union[Text, DiffSyncModel, Type[DiffSyncModel]]

--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -33,6 +33,13 @@ class Diff:
         `self.children[group][unique_id] == DiffElement(...)`
         """
 
+    def __len__(self):
+        """Total number of DiffElements stored herein."""
+        total = 0
+        for child in self.get_children():
+            total += len(child)
+        return total
+
     def complete(self):
         """Method to call when this Diff has been fully populated with data and is "complete".
 
@@ -204,6 +211,13 @@ class DiffElement:  # pylint: disable=too-many-instance-attributes
             f'{self.type} "{self.name}" : {self.keys} : '
             f"{self.source_name} → {self.dest_name} : {self.get_attrs_diffs()}"
         )
+
+    def __len__(self):
+        """Total number of DiffElements in this one, including itself."""
+        total = 1  # self
+        for child in self.get_children():
+            total += len(child)
+        return total
 
     @property
     def action(self) -> Optional[Text]:

--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -1,6 +1,6 @@
 """Diff and DiffElement classes for DiffSync.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/diffsync/utils.py
+++ b/diffsync/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for DiffSync library.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/diffsync/utils.py
+++ b/diffsync/utils.py
@@ -25,6 +25,11 @@ def intersection(lst1, lst2) -> List:
     return lst3
 
 
+def symmetric_difference(lst1, lst2) -> List:
+    """Calculate the symmetric difference of two lists."""
+    return sorted(set(lst1) ^ set(lst2))
+
+
 class OrderedDefaultDict(OrderedDict):
     """A combination of collections.OrderedDict and collections.DefaultDict behavior."""
 

--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -1,12 +1,12 @@
+# Example 1
 
-
-This is a simple example to show how diffsync can be used to compare and synchronize multiple data sources.
+This is a simple example to show how DiffSync can be used to compare and synchronize multiple data sources.
 
 For this example, we have a shared model for Device and Interface defined in `models.py`
 And we have 3 instances of DiffSync based on the same model but with different values (BackendA, BackendB & BackendC).
 
+First create and populate all 3 objects:
 
-First create and populate all 3 objects
 ```python
 from backend_a import BackendA
 from backend_b import BackendB
@@ -27,7 +27,8 @@ c.load()
 print(c.str())
 ```
 
-Configure verbosity of DiffSync's structured logging to console; the default is full verbosity (all logs including debugging)
+Configure verbosity of DiffSync's structured logging to console; the default is full verbosity (all logs including debugging):
+
 ```python
 from diffsync.logging import enable_console_logging
 enable_console_logging(verbosity=0)  # Show WARNING and ERROR logs only
@@ -35,25 +36,29 @@ enable_console_logging(verbosity=0)  # Show WARNING and ERROR logs only
 # enable_console_logging(verbosity=2)  # Also include DEBUG logs
 ```
 
-Show the differences between A and B
+Show the differences between A and B:
+
 ```python
 diff_a_b = a.diff_to(b)
 print(diff_a_b.str())
 ```
 
-Show the differences between B and C
+Show the differences between B and C:
+
 ```python
 diff_b_c = c.diff_from(b)
 print(diff_b_c.str())
 ```
 
-Synchronize A and B (update B with the contents of A)
+Synchronize A and B (update B with the contents of A):
+
 ```python
 a.sync_to(b)
 print(a.diff_to(b).str())
 ```
 
-Now A and B will show no differences
+Now A and B will show no differences:
+
 ```python
 diff_a_b = a.diff_to(b)
 print(diff_a_b.str())

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -24,15 +24,15 @@ ds1.sync_to(ds2, callback=print_callback)
 You should see output similar to the following:
 
 ```
-diff: Processed     1/  200 records.
-diff: Processed     3/  200 records.
+diff: Processed   1/200 records.
+diff: Processed   3/200 records.
 ...
-diff: Processed   199/  200 records.
-diff: Processed   200/  200 records.
-sync: Processed     1/  134 records.
-sync: Processed     2/  134 records.
+diff: Processed 199/200 records.
+diff: Processed 200/200 records.
+sync: Processed   1/134 records.
+sync: Processed   2/134 records.
 ...
-sync: Processed   134/  134 records.
+sync: Processed 134/134 records.
 ```
 
 A few points to note:

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -1,0 +1,44 @@
+# Example 2 - Callback Function
+
+This example shows how you can set up DiffSync to invoke a callback function to update its status as a sync proceeds. This could be used to, for example, update a status bar (such as with the [tqdm](https://github.com/tqdm/tqdm) library), although here for simplicity we'll just have the callback print directly to the console.
+
+```python
+from diffsync.logging import enable_console_logging
+from example2 import DiffSync1, DiffSync2, print_callback
+
+enable_console_logging(verbosity=0)  # Show WARNING and ERROR logs only
+
+# Create a DiffSync1 instance and populate it with records numbered 1-100
+ds1 = DiffSync1()
+ds1.populate(count=100)
+
+# Create a DiffSync2 instance and populate it with 100 random records in the range 1-200
+ds2 = DiffSync2()
+ds2.populate(count=100)
+
+# Identify and attempt to resolve the differences between the two,
+# periodically invoking print_callback() as DiffSync progresses
+ds1.sync_to(ds2, callback=print_callback)
+```
+
+You should see output similar to the following:
+
+```
+diff: Processed     1/  200 records.
+diff: Processed     3/  200 records.
+...
+diff: Processed   199/  200 records.
+diff: Processed   200/  200 records.
+sync: Processed     1/  134 records.
+sync: Processed     2/  134 records.
+...
+sync: Processed   134/  134 records.
+```
+
+A few points to note:
+
+- For each record in `ds1` and `ds2`, either it exists in both, exists only in `ds1`, or exists only in `ds2`.
+- The total number of records reported during the `"diff"` stage is the sum of the number of records in both `ds1` and `ds2`.
+- For this very simple set of models, the progress counter during the `"diff"` stage will increase at each step by 2 (if a corresponding pair of models is identified between`ds1` and `ds2`) or by 1 (if a model exists only in `ds1` or only in `ds2`).
+- The total number of records reported during the `"sync"` stage is the number of distinct records existing across `ds1` and `ds2` combined, so it will be less than the total reported during the `"diff"` stage.
+- By design for this example, `ds2` is populated semi-randomly with records, so the exact number reported during the `"sync"` stage may differ for you.

--- a/examples/example2/example2.py
+++ b/examples/example2/example2.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Example 2 - simple pair of DiffSync adapters and a callback function to report progress.
+
+Copyright (c) 2021 Network To Code, LLC <info@networktocode.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import random
+
+from diffsync import DiffSync, DiffSyncModel
+from diffsync.logging import enable_console_logging
+
+
+class Number(DiffSyncModel):
+    """Simple model that consists only of a number."""
+
+    _modelname = "number"
+    _identifiers = ("number",)
+
+    number: int
+
+
+class DiffSync1(DiffSync):
+    """DiffSync adapter that contains a number of Numbers constructed in order."""
+
+    number = Number
+
+    top_level = ["number"]
+
+    def populate(self, count):
+        """Construct Numbers from 1 to count."""
+        for i in range(count):
+            self.add(Number(number=(i + 1)))
+
+
+class DiffSync2(DiffSync):
+    """DiffSync adapter that contains a number of Numbers spread randomly across a range."""
+
+    number = Number
+
+    top_level = ["number"]
+
+    def populate(self, count):
+        """Construct count numbers in the range (1 - 2*count)."""
+        prev = 0
+        for i in range(count):  # pylint: disable=unused-variable
+            num = prev + random.randint(1, 2)  # nosec
+            self.add(Number(number=num))
+            prev = num
+
+
+def print_callback(stage, current, total):
+    """Callback for DiffSync; stage is "diff"/"sync", current is records processed to date, total is self-evident."""
+    print(f"{stage}: Processed {current:>5}/{total:>5} records.")
+
+
+def main():
+    """Create instances of DiffSync1 and DiffSync2 and sync them with a progress-reporting callback function."""
+    enable_console_logging(verbosity=0)  # Show WARNING and ERROR logs only
+
+    # Create a DiffSync1 instance and populate it with records numbered 1-100
+    ds1 = DiffSync1()
+    ds1.populate(count=100)
+
+    # Create a DiffSync2 instance and populate it with 100 random records in the range 1-200
+    ds2 = DiffSync2()
+    ds2.populate(count=100)
+
+    # Identify and attempt to resolve the differences between the two,
+    # periodically invoking print_callback() as DiffSync progresses
+    ds1.sync_to(ds2, callback=print_callback)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example2/example2.py
+++ b/examples/example2/example2.py
@@ -61,7 +61,7 @@ class DiffSync2(DiffSync):
 
 def print_callback(stage, current, total):
     """Callback for DiffSync; stage is "diff"/"sync", current is records processed to date, total is self-evident."""
-    print(f"{stage}: Processed {current:>5}/{total:>5} records.")
+    print(f"{stage}: Processed {current:>3}/{total} records.")
 
 
 def main():

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -49,6 +49,12 @@ def test_diff_dict_with_no_diffs():
     assert diff.dict() == {}
 
 
+def test_diff_len_with_no_diffs():
+    diff = Diff()
+
+    assert len(diff) == 0
+
+
 def test_diff_children():
     """Test the basic functionality of the Diff class when adding child elements."""
     diff = Diff()
@@ -115,6 +121,11 @@ def test_diff_dict_with_diffs(diff_with_children):
         },
         "person": {"Jimbo": {"+": {}}, "Sully": {"-": {}}},
     }
+
+
+def test_diff_len_with_diffs(diff_with_children):
+    assert len(diff_with_children) == 5
+    assert len(diff_with_children) == sum(count for count in diff_with_children.summary().values())
 
 
 def test_order_children_default(backend_a, backend_b):

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,6 +1,6 @@
 """Unit tests for the Diff class.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/unit/test_diff_element.py
+++ b/tests/unit/test_diff_element.py
@@ -1,6 +1,6 @@
 """Unit tests for the DiffElement class.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/unit/test_diff_element.py
+++ b/tests/unit/test_diff_element.py
@@ -57,6 +57,11 @@ def test_diff_element_dict_with_no_diffs():
     assert element.dict() == {}
 
 
+def test_diff_element_len_with_no_diffs():
+    element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
+    assert len(element) == 1
+
+
 def test_diff_element_attrs():
     """Test the basic functionality of the DiffElement class when setting and retrieving attrs."""
     element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
@@ -109,6 +114,13 @@ def test_diff_element_dict_with_diffs():
     assert element.dict() == {"+": {"description": "my interface", "interface_type": "ethernet"}}
     element.add_attrs(dest={"description": "your interface"})
     assert element.dict() == {"-": {"description": "your interface"}, "+": {"description": "my interface"}}
+
+
+def test_diff_element_len_with_diffs():
+    element = DiffElement("interface", "eth0", {"device_name": "device1", "name": "eth0"})
+    element.add_attrs(source={"interface_type": "ethernet", "description": "my interface"})
+    element.add_attrs(dest={"description": "your interface"})
+    assert len(element) == 1
 
 
 def test_diff_element_dict_with_diffs_no_attrs():
@@ -172,3 +184,8 @@ def test_diff_element_dict_with_child_diffs(diff_element_with_children):
             "lo1": {"-": {"description": "Loopback 1"}},
         },
     }
+
+
+def test_diff_element_len_with_child_diffs(diff_element_with_children):
+    assert len(diff_element_with_children) == 5
+    assert len(diff_element_with_children) == sum(count for count in diff_element_with_children.summary().values())

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -1,6 +1,6 @@
 """Unit tests for the DiffSync class.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -43,6 +43,10 @@ def test_diffsync_str_with_no_data(generic_diffsync):
     assert generic_diffsync.str() == ""
 
 
+def test_diffsync_len_with_no_data(generic_diffsync):
+    assert len(generic_diffsync) == 0
+
+
 def test_diffsync_diff_self_with_no_data_has_no_diffs(generic_diffsync):
     assert generic_diffsync.diff_from(generic_diffsync).has_diffs() is False
     assert generic_diffsync.diff_to(generic_diffsync).has_diffs() is False
@@ -285,6 +289,10 @@ unused: []\
     )
 
 
+def test_diffsync_len_with_data(backend_a):
+    assert len(backend_a) == 23
+
+
 def test_diffsync_diff_self_with_data_has_no_diffs(backend_a):
     # Self diff should always show no diffs!
     assert backend_a.diff_from(backend_a).has_diffs() is False
@@ -328,6 +336,24 @@ def test_diffsync_diff_from_with_custom_diff_class(backend_a, backend_b):
     assert diff_ba.is_complete is True
 
 
+def test_diffsync_diff_with_callback(backend_a, backend_b):
+    last_value = {"current": 0, "total": 0}
+
+    def callback(stage, current, total):
+        assert stage == "diff"
+        last_value["current"] = current
+        last_value["total"] = total
+
+    expected = len(backend_a) + len(backend_b)
+
+    backend_a.diff_from(backend_b, callback=callback)
+    assert last_value == {"current": expected, "total": expected}
+
+    last_value = {"current": 0, "total": 0}
+    backend_a.diff_to(backend_b, callback=callback)
+    assert last_value == {"current": expected, "total": expected}
+
+
 def test_diffsync_sync_from(backend_a, backend_b):
     backend_a.sync_complete = mock.Mock()
     backend_b.sync_complete = mock.Mock()
@@ -366,6 +392,20 @@ def test_diffsync_sync_from(backend_a, backend_b):
         backend_a.get_by_uids(["nyc", "sfo"], Device)
     with pytest.raises(ObjectNotFound):
         backend_a.get_by_uids(["nyc", "sfo"], "device")
+
+
+def test_diffsync_sync_with_callback(backend_a, backend_b):
+    last_value = {"current": 0, "total": 0}
+
+    def callback(stage, current, total):
+        assert stage in ("diff", "sync")
+        last_value["current"] = current
+        last_value["total"] = total
+
+    expected = len(backend_a.diff_from(backend_b))
+
+    backend_a.sync_from(backend_b, callback=callback)
+    assert last_value == {"current": expected, "total": expected}
 
 
 def check_successful_sync_log_sanity(log, src, dst, flags):

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -1,6 +1,6 @@
 """Verification that the provided example code works correctly.
 
-Copyright (c) 2020 Network To Code, LLC <info@networktocode.com>
+Copyright (c) 2020-2021 Network To Code, LLC <info@networktocode.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -27,3 +27,11 @@ def test_example_1():
     example1_main = join(example1_dir, "main.py")
     # Run it and make sure it doesn't raise an exception or otherwise exit with a non-zero code.
     subprocess.run(example1_main, cwd=example1_dir, check=True)
+
+
+def test_example_2():
+    """Test that the "example2" script runs successfully."""
+    example2_dir = join(EXAMPLES, "example2")
+    example2_main = join(example2_dir, "example2.py")
+    # Run it and make sure it doesn't raise an exception or otherwise exit with a non-zero code.
+    subprocess.run(example2_main, cwd=example2_dir, check=True)


### PR DESCRIPTION
Fixes #47.

Added optional `callback` argument to `diff_from/diff_to/sync_from/sync_to` APIs. This allows the caller to provide a callback function which will be invoked perioidically as `callback(stage, current, total)` during the diff and sync processes, which can be used to print status to the console or to update a progress bar - useful especially during long-running diffs and syncs of large data sets such as an [import from NetBox to Nautobot](https://github.com/nautobot/nautobot-plugin-netbox-importer/pull/23).