### PR TITLE
Extend sync_to|from to accept a Diff

### DIFF
--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -461,7 +461,8 @@ class DiffSync:
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
         callback: Optional[Callable[[Text, int, int], None]] = None,
-    ):
+        diff: Diff = None,
+    ):  # pylint: disable=too-many-arguments:
         """Synchronize data from the given source DiffSync object into the current DiffSync object.
 
         Args:
@@ -470,8 +471,10 @@ class DiffSync:
             flags (DiffSyncFlags): Flags influencing the behavior of this sync.
             callback (function): Function with parameters (stage, current, total), to be called at intervals as the
                 calculation of the diff and subsequent sync proceed.
+            diff (Diff): An existing diff to be used rather than generating a completely new diff.
         """
-        diff = self.diff_from(source, diff_class=diff_class, flags=flags, callback=callback)
+        if not diff:
+            diff = self.diff_from(source, diff_class=diff_class, flags=flags, callback=callback)
         syncer = DiffSyncSyncer(diff=diff, src_diffsync=source, dst_diffsync=self, flags=flags, callback=callback)
         result = syncer.perform_sync()
         if result:
@@ -483,7 +486,8 @@ class DiffSync:
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
         callback: Optional[Callable[[Text, int, int], None]] = None,
-    ):
+        diff: Diff = None,
+    ):  # pylint: disable=too-many-arguments
         """Synchronize data from the current DiffSync object into the given target DiffSync object.
 
         Args:
@@ -492,8 +496,9 @@ class DiffSync:
             flags (DiffSyncFlags): Flags influencing the behavior of this sync.
             callback (function): Function with parameters (stage, current, total), to be called at intervals as the
                 calculation of the diff and subsequent sync proceed.
+            diff (Diff): An existing diff that will be used when determining what needs to be synced.
         """
-        target.sync_from(self, diff_class=diff_class, flags=flags, callback=callback)
+        target.sync_from(self, diff_class=diff_class, flags=flags, callback=callback, diff=diff)
 
     def sync_complete(
         self,

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -486,7 +486,7 @@ class DiffSync:
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
         callback: Optional[Callable[[Text, int, int], None]] = None,
-        diff: Diff = None,
+        diff: Optional[Diff] = None,
     ):  # pylint: disable=too-many-arguments
         """Synchronize data from the current DiffSync object into the given target DiffSync object.
 

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -461,7 +461,7 @@ class DiffSync:
         diff_class: Type[Diff] = Diff,
         flags: DiffSyncFlags = DiffSyncFlags.NONE,
         callback: Optional[Callable[[Text, int, int], None]] = None,
-        diff: Diff = None,
+        diff: Optional[Diff] = None,
     ):  # pylint: disable=too-many-arguments:
         """Synchronize data from the given source DiffSync object into the current DiffSync object.
 

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -23,7 +23,7 @@ import structlog  # type: ignore
 
 from .diff import Diff
 from .enum import DiffSyncModelFlags, DiffSyncFlags, DiffSyncStatus
-from .exceptions import ObjectAlreadyExists, ObjectStoreWrongType, ObjectNotFound
+from .exceptions import DiffClassMismatch, ObjectAlreadyExists, ObjectStoreWrongType, ObjectNotFound
 from .helpers import DiffSyncDiffer, DiffSyncSyncer
 
 
@@ -473,6 +473,13 @@ class DiffSync:
                 calculation of the diff and subsequent sync proceed.
             diff (Diff): An existing diff to be used rather than generating a completely new diff.
         """
+        if diff_class and diff:
+            if not isinstance(diff, diff_class):
+                raise DiffClassMismatch(
+                    f"The provided diff's class ({diff.__class__.__name__}) does not match the diff_class: {diff_class.__name__}",
+                )
+
+        # Generate the diff if an existing diff was not provided
         if not diff:
             diff = self.diff_from(source, diff_class=diff_class, flags=flags, callback=callback)
         syncer = DiffSyncSyncer(diff=diff, src_diffsync=source, dst_diffsync=self, flags=flags, callback=callback)

--- a/diffsync/exceptions.py
+++ b/diffsync/exceptions.py
@@ -51,3 +51,11 @@ class ObjectNotFound(ObjectStoreException):
 
 class ObjectStoreWrongType(ObjectStoreException):
     """Exception raised when trying to store a DiffSyncModel of the wrong type."""
+
+
+class DiffException(Exception):
+    """Base class for various failures related to Diff operations."""
+
+
+class DiffClassMismatch(DiffException):
+    """Exception raised when a diff object is not the same as the expected diff_class."""

--- a/examples/01-multiple-data-sources/README.md
+++ b/examples/01-multiple-data-sources/README.md
@@ -57,6 +57,8 @@ Synchronize A and B (update B with the contents of A):
 ```python
 a.sync_to(b)
 print(a.diff_to(b).str())
+# Alternatively you can pass in the diff object from above to prevent another diff calculation
+a.sync_to(b, diff_a_b)
 ```
 
 Now A and B will show no differences:

--- a/examples/01-multiple-data-sources/README.md
+++ b/examples/01-multiple-data-sources/README.md
@@ -58,7 +58,7 @@ Synchronize A and B (update B with the contents of A):
 a.sync_to(b)
 print(a.diff_to(b).str())
 # Alternatively you can pass in the diff object from above to prevent another diff calculation
-a.sync_to(b, diff_a_b)
+# a.sync_to(b, diff=diff_a_b)
 ```
 
 Now A and B will show no differences:

--- a/examples/01-multiple-data-sources/main.py
+++ b/examples/01-multiple-data-sources/main.py
@@ -69,7 +69,7 @@ def main():
     pprint.pprint(diff_a_b.dict(), width=120)
 
     print("Syncing changes from Backend A to Backend B...")
-    backend_a.sync_to(backend_b)
+    backend_a.sync_to(backend_b, diff=diff_a_b)
     print("Getting updated diffs from Backend A to Backend B...")
     print(backend_a.diff_to(backend_b).str())
 

--- a/examples/03-remote-system/main.py
+++ b/examples/03-remote-system/main.py
@@ -41,7 +41,7 @@ def main():
 
     if args.sync:
         print("Updating the list of countries in Nautobot ...")
-        nautobot.sync_from(local, flags=flags, diff_class=AlphabeticalOrderDiff)
+        nautobot.sync_from(local, flags=flags, diff_class=AlphabeticalOrderDiff, diff=diff)
 
 
 if __name__ == "__main__":

--- a/examples/03-remote-system/main.py
+++ b/examples/03-remote-system/main.py
@@ -40,6 +40,8 @@ def main():
         print(diff.str())
 
     if args.sync:
+        if not args.diff:
+            diff = None
         print("Updating the list of countries in Nautobot ...")
         nautobot.sync_from(local, flags=flags, diff_class=AlphabeticalOrderDiff, diff=diff)
 

--- a/examples/04-get-update-instantiate/backends.py
+++ b/examples/04-get-update-instantiate/backends.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from models import Site, Device, Interface
+from models import Site, Device, Interface  # pylint: disable=no-name-in-module
 from diffsync import DiffSync
 
 BACKEND_DATA_A = [


### PR DESCRIPTION
Fixes #76 

This allows a user to pass in an existing `Diff` object into `sync_to|from` to prevent another diff from being calculated.

- Updated examples, docs, and tests.
- Remove print statement within tests