### PR TITLE
Fix get() by modelname

### DIFF
--- a/diffsync/store/__init__.py
+++ b/diffsync/store/__init__.py
@@ -194,9 +194,9 @@ class BaseStore:
         """Get object class and model name for a model."""
         if isinstance(model, str):
             modelname = model
-            if not hasattr(self, model):
+            if not hasattr(self.diffsync, model):
                 return None, modelname
-            object_class = getattr(self, model)
+            object_class = getattr(self.diffsync, model)
         else:
             object_class = model
             modelname = model.get_type()
@@ -216,7 +216,7 @@ class BaseStore:
             uid = object_class.create_unique_id(**identifier)
         else:
             raise ValueError(
-                f"Invalid args: ({model}, {identifier}): "
-                f"either {model} should be a class/instance or {identifier} should be a str"
+                f"Invalid args: ({model}, {object_class}, {identifier}): "
+                f"either {object_class} should be a class/instance or {identifier} should be a str"
             )
         return uid

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -115,6 +115,7 @@ def test_diffsync_add_raises_already_exists_with_updated_object(generic_diffsync
 
 
 def test_diffsync_get_or_instantiate_create_non_existent_object(generic_diffsync):
+    generic_diffsync.interface = Interface
     intf_identifiers = {"device_name": "device1", "name": "eth1"}
 
     # Assert that the object does not currently exist.
@@ -124,6 +125,7 @@ def test_diffsync_get_or_instantiate_create_non_existent_object(generic_diffsync
     obj, created = generic_diffsync.get_or_instantiate(Interface, intf_identifiers)
     assert created
     assert obj is generic_diffsync.get(Interface, intf_identifiers)
+    assert obj is generic_diffsync.get("interface", intf_identifiers)
 
 
 def test_diffsync_get_or_instantiate_retrieve_existing_object(generic_diffsync):
@@ -150,6 +152,7 @@ def test_diffsync_get_or_instantiate_retrieve_existing_object_w_attrs(generic_di
 
 
 def test_diffsync_get_or_instantiate_retrieve_create_non_existent_w_attrs(generic_diffsync):
+    generic_diffsync.interface = Interface
     intf_identifiers = {"device_name": "device1", "name": "eth1"}
     intf_attrs = {"interface_type": "1000base-t", "description": "Testing"}
 
@@ -158,6 +161,7 @@ def test_diffsync_get_or_instantiate_retrieve_create_non_existent_w_attrs(generi
     assert obj.interface_type == "1000base-t"
     assert obj.description == "Testing"
     assert obj is generic_diffsync.get(Interface, intf_identifiers)
+    assert obj is generic_diffsync.get("interface", intf_identifiers)
 
 
 def test_diffsync_get_or_instantiate_retrieve_existing_object_wo_attrs(generic_diffsync):


### PR DESCRIPTION
This appears to be a regression in 1.5.0, which I noticed in working on https://github.com/nautobot/nautobot-plugin-netbox-importer/pull/75 - the pattern `diffsync.get("modelname", {identifier: value, ...})` was failing with an error:

```
ValueError: Invalid args: (customfieldchoice, {'field': {'name': 'Custom Choices Field'}, 'value': 'alpha'}): either customfieldchoice should be a class/instance or {'field': {'name': 
'Custom Choices Field'}, 'value': 'alpha'} should be a str
```

The root cause was that `BaseStore._get_object_class_and_model()` was looking for the model class by name on `self` rather than on `self.diffsync`, which as such would always fail since the model classes are an expected attribute of the DiffSync object not the Store.

I've added a unit test to reproduce the issue, fixed the issue, and clarified the error message.