### PR TITLE
Remove outdated comment from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,6 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # pytest-redis only supported in >3.7
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: "ubuntu-20.04"
     env:


### PR DESCRIPTION
We no longer support Python 3.6, so this comment was no longer needed.