### PR TITLE
Updates for new release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.0 - 2022-07-09
+
+### Changed
+
+- #120 - Dropped support for Python 3.6, new minimum is Python 3.7
+
 ## v1.5.1 - 2022-06-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "diffsync"
-version = "1.5.1"
+version = "1.6.0"
 description = "Library to easily sync/diff/update 2 different data sources"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Release 1.6.0 for removing Python 3.6 support.