### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,15 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": ["develop"],
   "constraints": {
-    "python": "3.7"
+    "python": ">=3.7",
+    "poetry": ">=1.1.14"
   },
   "enabledManagers": ["pip_requirements", "poetry"],
   "extends": [
     "config:base"
   ],
-  "constraints": {
-    "poetry": ">=1.1.14"
-  },
   "labels": [
     "dependencies"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
   "extends": [
     "config:base"
   ],
+  "constraints": {
+    "poetry": ">=1.1.14"
+  },
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
Currently renovate appears to be using poetry 1.1.13, which is a problem because of [this](https://github.com/python-poetry/poetry/issues/6045). According to [this](https://github.com/python-poetry/poetry/issues/6045), we can apply constraints to the Poetry version used by renovate with the change I did here.