### PR TITLE
Add 'skip' counter to diff.summary()

### DIFF
--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -29,11 +29,11 @@ class Diff:
     def __init__(self):
         """Initialize a new, empty Diff object."""
         self.children = OrderedDefaultDict(dict)
-        self.models_processed = 0
         """DefaultDict for storing DiffElement objects.
 
         `self.children[group][unique_id] == DiffElement(...)`
         """
+        self.models_processed = 0
 
     def __len__(self):
         """Total number of DiffElements stored herein."""

--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -119,8 +119,10 @@ class Diff:
         summary[DiffSyncActions.SKIP] = (
             self.models_processed
             - summary[DiffSyncActions.CREATE]
+            # Updated elements are doubly accumulated in models_processed as they exist in SCR and DST.
             - 2 * summary[DiffSyncActions.UPDATE]
             - summary[DiffSyncActions.DELETE]
+            # 'no-change' elements are doubly accumulated in models_processed as they exist in SCR and DST.
             - 2 * summary["no-change"]
         )
         return summary

--- a/diffsync/diff.py
+++ b/diffsync/diff.py
@@ -29,6 +29,7 @@ class Diff:
     def __init__(self):
         """Initialize a new, empty Diff object."""
         self.children = OrderedDefaultDict(dict)
+        self.models_processed = 0
         """DefaultDict for storing DiffElement objects.
 
         `self.children[group][unique_id] == DiffElement(...)`
@@ -115,6 +116,13 @@ class Diff:
             child_summary = child.summary()
             for key in summary:
                 summary[key] += child_summary[key]
+        summary[DiffSyncActions.SKIP] = (
+            self.models_processed
+            - summary[DiffSyncActions.CREATE]
+            - 2 * summary[DiffSyncActions.UPDATE]
+            - summary[DiffSyncActions.DELETE]
+            - 2 * summary["no-change"]
+        )
         return summary
 
     def str(self, indent: int = 0):

--- a/diffsync/enum.py
+++ b/diffsync/enum.py
@@ -95,4 +95,5 @@ class DiffSyncActions:  # pylint: disable=too-few-public-methods
     CREATE = "create"
     UPDATE = "update"
     DELETE = "delete"
+    SKIP = "skip"
     NO_CHANGE = None

--- a/diffsync/helpers.py
+++ b/diffsync/helpers.py
@@ -93,6 +93,7 @@ class DiffSyncDiffer:  # pylint: disable=too-many-instance-attributes
                 self.diff.add(diff_element)
 
         self.logger.info("Diff calculation complete")
+        self.diff.models_processed = self.models_processed
         self.diff.complete()
         return self.diff
 

--- a/examples/06-ip-prefixes/README.md
+++ b/examples/06-ip-prefixes/README.md
@@ -82,7 +82,7 @@ From this `diff`, we can check the summary of what would happen.
 
 ```py
 >>> diff.summary()
-{'create': 2, 'update': 1, 'delete': 1, 'no-change': 0}
+{'create': 2, 'update': 1, 'delete': 1, 'no-change': 0, 'skip': 0}
 ```
 
 And, also go into the details. We can see how the `'+'` and + `'-'` represent the actual changes in the target adapter: create, delete or update (when both symbols appear).
@@ -119,5 +119,5 @@ Now, if we reload the IPAM B, and try to check the difference, we should see no 
 >>> new_ipam_b.load()
 >>> diff = ipam_a.diff_to(new_ipam_b)
 >>> diff.summary()
-{'create': 0, 'update': 0, 'delete': 0, 'no-change': 3}
+{'create': 0, 'update': 0, 'delete': 0, 'no-change': 3, 'skip': 0}
 ```

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -449,6 +449,8 @@ def diff_with_children():
     address_element.add_attrs(source={"state": "NC"}, dest={"state": "NC"})
     diff.add(address_element)
 
+    diff.models_processed = 8
+
     return diff
 
 

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -34,7 +34,7 @@ def test_diff_empty():
 def test_diff_summary_with_no_diffs():
     diff = Diff()
 
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 0}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 0, "skip": 0}
 
 
 def test_diff_str_with_no_diffs():
@@ -91,7 +91,7 @@ def test_diff_summary_with_diffs(diff_with_children):
     # Delete person "Sully"
     # Update interface "device1_eth0"
     # No change to address "RTP" and device "device1"
-    assert diff_with_children.summary() == {"create": 1, "update": 1, "delete": 1, "no-change": 2}
+    assert diff_with_children.summary() == {"create": 1, "update": 1, "delete": 1, "no-change": 2, "skip": 0}
 
 
 def test_diff_str_with_diffs(diff_with_children):

--- a/tests/unit/test_diffsync.py
+++ b/tests/unit/test_diffsync.py
@@ -810,30 +810,30 @@ def test_diffsync_diff_with_skip_unmatched_src_flag(
     backend_a, backend_a_with_extra_models, backend_a_minus_some_models
 ):
     diff = backend_a.diff_from(backend_a_with_extra_models)
-    assert diff.summary() == {"create": 2, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 2, "update": 0, "delete": 0, "no-change": 23, "skip": 0}
 
     # SKIP_UNMATCHED_SRC should mean that extra models in the src are not flagged for creation in the dest
     diff = backend_a.diff_from(backend_a_with_extra_models, flags=DiffSyncFlags.SKIP_UNMATCHED_SRC)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23, "skip": 2}
 
     # SKIP_UNMATCHED_SRC should NOT mean that extra models in the dst are not flagged for deletion in the src
     diff = backend_a.diff_from(backend_a_minus_some_models, flags=DiffSyncFlags.SKIP_UNMATCHED_SRC)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 12, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 12, "no-change": 11, "skip": 0}
 
 
 def test_diffsync_diff_with_skip_unmatched_dst_flag(
     backend_a, backend_a_with_extra_models, backend_a_minus_some_models
 ):
     diff = backend_a.diff_from(backend_a_minus_some_models)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 12, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 12, "no-change": 11, "skip": 0}
 
     # SKIP_UNMATCHED_DST should mean that missing models in the src are not flagged for deletion from the dest
     diff = backend_a.diff_from(backend_a_minus_some_models, flags=DiffSyncFlags.SKIP_UNMATCHED_DST)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 11, "skip": 2}
 
     # SKIP_UNMATCHED_DST should NOT mean that extra models in the src are not flagged for creation in the dest
     diff = backend_a.diff_from(backend_a_with_extra_models, flags=DiffSyncFlags.SKIP_UNMATCHED_DST)
-    assert diff.summary() == {"create": 2, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 2, "update": 0, "delete": 0, "no-change": 23, "skip": 0}
 
 
 def test_diffsync_diff_with_skip_unmatched_both_flag(
@@ -841,11 +841,11 @@ def test_diffsync_diff_with_skip_unmatched_both_flag(
 ):
     # SKIP_UNMATCHED_BOTH should mean that extra models in the src are not flagged for creation in the dest
     diff = backend_a.diff_from(backend_a_with_extra_models, flags=DiffSyncFlags.SKIP_UNMATCHED_BOTH)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23, "skip": 2}
 
     # SKIP_UNMATCHED_BOTH should mean that missing models in the src are not flagged for deletion from the dest
     diff = backend_a.diff_from(backend_a_minus_some_models, flags=DiffSyncFlags.SKIP_UNMATCHED_BOTH)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 11, "skip": 2}
 
 
 def test_diffsync_sync_with_skip_unmatched_src_flag(backend_a, backend_a_with_extra_models):

--- a/tests/unit/test_diffsync_model_flags.py
+++ b/tests/unit/test_diffsync_model_flags.py
@@ -24,20 +24,20 @@ from diffsync.exceptions import ObjectNotFound
 def test_diffsync_diff_with_skip_unmatched_src_flag_on_models(backend_a, backend_a_with_extra_models):
     # Validate that there are 2 extras objects out of the box
     diff = backend_a.diff_from(backend_a_with_extra_models)
-    assert diff.summary() == {"create": 2, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 2, "update": 0, "delete": 0, "no-change": 23, "skip": 0}
 
     # Check that only 1 object is affected by the flag
     backend_a_with_extra_models.get(
         backend_a_with_extra_models.site, "lax"
     ).model_flags |= DiffSyncModelFlags.SKIP_UNMATCHED_SRC
     diff = backend_a.diff_from(backend_a_with_extra_models)
-    assert diff.summary() == {"create": 1, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 1, "update": 0, "delete": 0, "no-change": 23, "skip": 1}
 
     backend_a_with_extra_models.get(
         backend_a_with_extra_models.device, "nyc-spine3"
     ).model_flags |= DiffSyncModelFlags.SKIP_UNMATCHED_SRC
     diff = backend_a.diff_from(backend_a_with_extra_models)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23, "skip": 2}
 
 
 def test_diffsync_sync_with_skip_unmatched_src_flag_on_models(backend_a, backend_a_with_extra_models):
@@ -58,23 +58,23 @@ def test_diffsync_sync_with_skip_unmatched_src_flag_on_models(backend_a, backend
     assert "nyc-spine3" not in backend_a.get(backend_a.site, "nyc").devices
 
     diff = backend_a.diff_from(backend_a_with_extra_models)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 0, "no-change": 23, "skip": 2}
 
 
 def test_diffsync_diff_with_skip_unmatched_dst_flag_on_models(backend_a, backend_a_minus_some_models):
     # Validate that there are 3 extras objects out of the box
     diff = backend_a.diff_from(backend_a_minus_some_models)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 12, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 12, "no-change": 11, "skip": 0}
 
     # Check that only the device "rdu-spine1" and its 2 interfaces are affected by the flag
     backend_a.get(backend_a.device, "rdu-spine1").model_flags |= DiffSyncModelFlags.SKIP_UNMATCHED_DST
     diff = backend_a.diff_from(backend_a_minus_some_models)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 9, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 9, "no-change": 11, "skip": 1}
 
     # Check that only one additional device "sfo-spine2" and its 3 interfaces are affected by the flag
     backend_a.get(backend_a.device, "sfo-spine2").model_flags |= DiffSyncModelFlags.SKIP_UNMATCHED_DST
     diff = backend_a.diff_from(backend_a_minus_some_models)
-    assert diff.summary() == {"create": 0, "update": 0, "delete": 5, "no-change": 11}
+    assert diff.summary() == {"create": 0, "update": 0, "delete": 5, "no-change": 11, "skip": 2}
 
 
 def test_diffsync_sync_with_skip_unmatched_dst_flag_on_models(backend_a, backend_a_minus_some_models):


### PR DESCRIPTION
Closes #89 

Adding the processed model counter to the Diff object to be able to calculate the number of skipped models.