### PR TITLE
Type hinting overhaul.

### DIFF
--- a/diffsync/exceptions.py
+++ b/diffsync/exceptions.py
@@ -14,6 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from typing import TYPE_CHECKING, Union, Any
+
+if TYPE_CHECKING:
+    from diffsync import DiffSyncModel
+    from diffsync.diff import DiffElement
 
 
 class ObjectCrudException(Exception):
@@ -39,7 +44,7 @@ class ObjectStoreException(Exception):
 class ObjectAlreadyExists(ObjectStoreException):
     """Exception raised when trying to store a DiffSyncModel or DiffElement that is already being stored."""
 
-    def __init__(self, message, existing_object, *args, **kwargs):
+    def __init__(self, message: str, existing_object: Union["DiffSyncModel", "DiffElement"], *args: Any, **kwargs: Any):
         """Add existing_object to the exception to provide user with existing object."""
         self.existing_object = existing_object
         super().__init__(message, existing_object, *args, **kwargs)

--- a/diffsync/helpers.py
+++ b/diffsync/helpers.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from collections.abc import Iterable as ABCIterable, Mapping as ABCMapping
-from typing import Callable, Iterable, List, Mapping, Optional, Tuple, Type, TYPE_CHECKING
+from typing import Callable, List, Optional, Tuple, Type, TYPE_CHECKING, Dict, Iterable
 
 import structlog  # type: ignore
 
@@ -57,7 +57,7 @@ class DiffSyncDiffer:  # pylint: disable=too-many-instance-attributes
         self.total_models = len(src_diffsync) + len(dst_diffsync)
         self.logger.debug(f"Diff calculation between these two datasets will involve {self.total_models} models")
 
-    def incr_models_processed(self, delta: int = 1):
+    def incr_models_processed(self, delta: int = 1) -> None:
         """Increment self.models_processed, then call self.callback if present."""
         if delta:
             self.models_processed += delta
@@ -136,7 +136,9 @@ class DiffSyncDiffer:  # pylint: disable=too-many-instance-attributes
         return diff_elements
 
     @staticmethod
-    def validate_objects_for_diff(object_pairs: Iterable[Tuple[Optional["DiffSyncModel"], Optional["DiffSyncModel"]]]):
+    def validate_objects_for_diff(
+        object_pairs: Iterable[Tuple[Optional["DiffSyncModel"], Optional["DiffSyncModel"]]]
+    ) -> None:
         """Check whether all DiffSyncModels in the given dictionary are valid for comparison to one another.
 
         Helper method for `diff_object_list`.
@@ -234,7 +236,7 @@ class DiffSyncDiffer:  # pylint: disable=too-many-instance-attributes
         diff_element: DiffElement,
         src_obj: Optional["DiffSyncModel"],
         dst_obj: Optional["DiffSyncModel"],
-    ):
+    ) -> DiffElement:
         """For all children of the given DiffSyncModel pair, diff recursively, adding diffs to the given diff_element.
 
         Helper method to `calculate_diffs`, usually doesn't need to be called directly.
@@ -242,7 +244,7 @@ class DiffSyncDiffer:  # pylint: disable=too-many-instance-attributes
         These helper methods work in a recursive cycle:
         diff_object_list -> diff_object_pair -> diff_child_objects -> diff_object_list -> etc.
         """
-        children_mapping: Mapping[str, str]
+        children_mapping: Dict[str, str]
         if src_obj and dst_obj:
             # Get the subset of child types common to both src_obj and dst_obj
             src_mapping = src_obj.get_children_mapping()
@@ -308,7 +310,7 @@ class DiffSyncSyncer:  # pylint: disable=too-many-instance-attributes
         self.model_class: Type["DiffSyncModel"]
         self.action: Optional[str] = None
 
-    def incr_elements_processed(self, delta: int = 1):
+    def incr_elements_processed(self, delta: int = 1) -> None:
         """Increment self.elements_processed, then call self.callback if present."""
         if delta:
             self.elements_processed += delta
@@ -319,7 +321,7 @@ class DiffSyncSyncer:  # pylint: disable=too-many-instance-attributes
         """Perform data synchronization based on the provided diff.
 
         Returns:
-            bool: True if any changes were actually performed, else False.
+            True if any changes were actually performed, else False.
         """
         changed = False
         self.base_logger.info("Beginning sync")
@@ -401,14 +403,14 @@ class DiffSyncSyncer:  # pylint: disable=too-many-instance-attributes
         return changed
 
     def sync_model(  # pylint: disable=too-many-branches, unused-argument
-        self, src_model: Optional["DiffSyncModel"], dst_model: Optional["DiffSyncModel"], ids: Mapping, attrs: Mapping
+        self, src_model: Optional["DiffSyncModel"], dst_model: Optional["DiffSyncModel"], ids: Dict, attrs: Dict
     ) -> Tuple[bool, Optional["DiffSyncModel"]]:
         """Create/update/delete the current DiffSyncModel with current ids/attrs, and update self.status and self.message.
 
         Helper method to `sync_diff_element`.
 
         Returns:
-            tuple: (changed, model) where model may be None if an error occurred
+            (changed, model) where model may be None if an error occurred
         """
         if self.action is None:
             status = DiffSyncStatus.SUCCESS
@@ -451,7 +453,7 @@ class DiffSyncSyncer:  # pylint: disable=too-many-instance-attributes
 
         return (True, dst_model)
 
-    def log_sync_status(self, action: Optional[str], status: DiffSyncStatus, message: str):
+    def log_sync_status(self, action: Optional[str], status: DiffSyncStatus, message: str) -> None:
         """Log the current sync status at the appropriate verbosity with appropriate context.
 
         Helper method to `sync_diff_element`/`sync_model`.

--- a/diffsync/logging.py
+++ b/diffsync/logging.py
@@ -22,7 +22,7 @@ import structlog  # type: ignore
 from packaging import version
 
 
-def enable_console_logging(verbosity=0):
+def enable_console_logging(verbosity: int = 0) -> None:
     """Enable formatted logging to console with the specified verbosity.
 
     See https://www.structlog.org/en/stable/development.html as a reference
@@ -52,7 +52,7 @@ def enable_console_logging(verbosity=0):
     processors.append(structlog.dev.ConsoleRenderer())
 
     structlog.configure(
-        processors=processors,
+        processors=processors,  # type: ignore[arg-type]
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
@@ -60,7 +60,7 @@ def enable_console_logging(verbosity=0):
     )
 
 
-def _structlog_exception_formatter_required():
+def _structlog_exception_formatter_required() -> bool:
     """Determine if structlog exception formatter is needed.
 
     Return True if structlog exception formatter should be loaded

--- a/diffsync/store/__init__.py
+++ b/diffsync/store/__init__.py
@@ -1,5 +1,5 @@
 """BaseStore module."""
-from typing import Dict, List, Mapping, Text, Tuple, Type, Union, TYPE_CHECKING, Optional, Set
+from typing import Dict, List, Tuple, Type, Union, TYPE_CHECKING, Optional, Set, Any
 import structlog  # type: ignore
 
 from diffsync.exceptions import ObjectNotFound
@@ -13,14 +13,18 @@ class BaseStore:
     """Reference store to be implemented in different backends."""
 
     def __init__(
-        self, *args, diffsync: Optional["DiffSync"] = None, name: str = "", **kwargs  # pylint: disable=unused-argument
+        self,  # pylint: disable=unused-argument
+        *args: Any,  # pylint: disable=unused-argument
+        diffsync: Optional["DiffSync"] = None,
+        name: str = "",
+        **kwargs: Any,  # pylint: disable=unused-argument
     ) -> None:
         """Init method for BaseStore."""
         self.diffsync = diffsync
         self.name = name or self.__class__.__name__
         self._log = structlog.get_logger().new(store=self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Render store name."""
         return self.name
 
@@ -28,12 +32,12 @@ class BaseStore:
         """Get all the model names stored.
 
         Return:
-            Set[str]: Set of all the model names.
+            Set of all the model names.
         """
         raise NotImplementedError
 
     def get(
-        self, *, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]], identifier: Union[Text, Mapping]
+        self, *, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]], identifier: Union[str, Dict]
     ) -> "DiffSyncModel":
         """Get one object from the data store based on its unique id.
 
@@ -47,19 +51,19 @@ class BaseStore:
         """
         raise NotImplementedError
 
-    def get_all(self, *, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]]) -> List["DiffSyncModel"]:
+    def get_all(self, *, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]]) -> List["DiffSyncModel"]:
         """Get all objects of a given type.
 
         Args:
             model: DiffSyncModel class or instance, or modelname string, that defines the type of the objects to retrieve
 
         Returns:
-            List[DiffSyncModel]: List of Object
+            List of Object
         """
         raise NotImplementedError
 
     def get_by_uids(
-        self, *, uids: List[Text], model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]]
+        self, *, uids: List[str], model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]]
     ) -> List["DiffSyncModel"]:
         """Get multiple objects from the store by their unique IDs/Keys and type.
 
@@ -72,16 +76,16 @@ class BaseStore:
         """
         raise NotImplementedError
 
-    def remove_item(self, modelname: str, uid: str):
+    def remove_item(self, modelname: str, uid: str) -> None:
         """Remove one item from store."""
         raise NotImplementedError
 
-    def remove(self, *, obj: "DiffSyncModel", remove_children: bool = False):
+    def remove(self, *, obj: "DiffSyncModel", remove_children: bool = False) -> None:
         """Remove a DiffSyncModel object from the store.
 
         Args:
-            obj (DiffSyncModel): object to remove
-            remove_children (bool): If True, also recursively remove any children of this object
+            obj: object to remove
+            remove_children: If True, also recursively remove any children of this object
 
         Raises:
             ObjectNotFound: if the object is not present
@@ -110,26 +114,26 @@ class BaseStore:
                             parent_id=uid,
                         )
 
-    def add(self, *, obj: "DiffSyncModel"):
+    def add(self, *, obj: "DiffSyncModel") -> None:
         """Add a DiffSyncModel object to the store.
 
         Args:
-            obj (DiffSyncModel): Object to store
+            obj: Object to store
 
         Raises:
             ObjectAlreadyExists: if a different object with the same uid is already present.
         """
         raise NotImplementedError
 
-    def update(self, *, obj: "DiffSyncModel"):
+    def update(self, *, obj: "DiffSyncModel") -> None:
         """Update a DiffSyncModel object to the store.
 
         Args:
-            obj (DiffSyncModel): Object to update
+            obj: Object to update
         """
         raise NotImplementedError
 
-    def count(self, *, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"], None] = None) -> int:
+    def count(self, *, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"], None] = None) -> int:
         """Returns the number of elements of a specific model, or all elements in the store if not specified."""
         raise NotImplementedError
 
@@ -139,12 +143,12 @@ class BaseStore:
         """Attempt to get the object with provided identifiers or instantiate it with provided identifiers and attrs.
 
         Args:
-            model (DiffSyncModel): The DiffSyncModel to get or create.
-            ids (Mapping): Identifiers for the DiffSyncModel to get or create with.
-            attrs (Mapping, optional): Attributes when creating an object if it doesn't exist. Defaults to None.
+            model: The DiffSyncModel to get or create.
+            ids: Identifiers for the DiffSyncModel to get or create with.
+            attrs: Attributes when creating an object if it doesn't exist. Defaults to None.
 
         Returns:
-            Tuple[DiffSyncModel, bool]: Provides the existing or new object and whether it was created or not.
+            Provides the existing or new object and whether it was created or not.
         """
         created = False
         try:
@@ -183,12 +187,12 @@ class BaseStore:
         """Attempt to update an existing object with provided ids/attrs or instantiate it with provided identifiers and attrs.
 
         Args:
-            model (DiffSyncModel): The DiffSyncModel to get or create.
-            ids (Dict): Identifiers for the DiffSyncModel to get or create with.
-            attrs (Dict): Attributes when creating/updating an object if it doesn't exist. Pass in empty dict, if no specific attrs.
+            model: The DiffSyncModel to get or create.
+            ids: Identifiers for the DiffSyncModel to get or create with.
+            attrs: Attributes when creating/updating an object if it doesn't exist. Pass in empty dict, if no specific attrs.
 
         Returns:
-            Tuple[DiffSyncModel, bool]: Provides the existing or new object and whether it was created or not.
+            Provides the existing or new object and whether it was created or not.
         """
         created = False
         try:
@@ -210,7 +214,7 @@ class BaseStore:
         """Attempt to update an existing object with provided ids/attrs or instantiate obj.
 
         Args:
-            instance: An instance of the DiffSyncModel to update or create.
+            obj: An instance of the DiffSyncModel to update or create.
 
         Returns:
             Provides the existing or new object and whether it was added or not.
@@ -234,7 +238,7 @@ class BaseStore:
         return obj, added
 
     def _get_object_class_and_model(
-        self, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]]
+        self, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]]
     ) -> Tuple[Union["DiffSyncModel", Type["DiffSyncModel"], None], str]:
         """Get object class and model name for a model."""
         if isinstance(model, str):
@@ -250,9 +254,9 @@ class BaseStore:
 
     @staticmethod
     def _get_uid(
-        model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]],
+        model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]],
         object_class: Union["DiffSyncModel", Type["DiffSyncModel"], None],
-        identifier: Union[Text, Mapping],
+        identifier: Union[str, Dict],
     ) -> str:
         """Get the related uid for a model and an identifier."""
         if isinstance(identifier, str):

--- a/diffsync/store/local.py
+++ b/diffsync/store/local.py
@@ -1,7 +1,7 @@
 """LocalStore module."""
 
 from collections import defaultdict
-from typing import List, Mapping, Text, Type, Union, TYPE_CHECKING, Dict, Set
+from typing import List, Type, Union, TYPE_CHECKING, Dict, Set, Any
 
 from diffsync.exceptions import ObjectNotFound, ObjectAlreadyExists
 from diffsync.store import BaseStore
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class LocalStore(BaseStore):
     """LocalStore class."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Init method for LocalStore."""
         super().__init__(*args, **kwargs)
 
@@ -24,12 +24,12 @@ class LocalStore(BaseStore):
         """Get all the model names stored.
 
         Return:
-            Set[str]: Set of all the model names.
+            Set of all the model names.
         """
         return set(self._data.keys())
 
     def get(
-        self, *, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]], identifier: Union[Text, Mapping]
+        self, *, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]], identifier: Union[str, Dict]
     ) -> "DiffSyncModel":
         """Get one object from the data store based on its unique id.
 
@@ -49,14 +49,14 @@ class LocalStore(BaseStore):
             raise ObjectNotFound(f"{modelname} {uid} not present in {str(self)}")
         return self._data[modelname][uid]
 
-    def get_all(self, *, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]]) -> List["DiffSyncModel"]:
+    def get_all(self, *, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]]) -> List["DiffSyncModel"]:
         """Get all objects of a given type.
 
         Args:
             model: DiffSyncModel class or instance, or modelname string, that defines the type of the objects to retrieve
 
         Returns:
-            List[DiffSyncModel]: List of Object
+            List of Object
         """
         if isinstance(model, str):
             modelname = model
@@ -66,7 +66,7 @@ class LocalStore(BaseStore):
         return list(self._data[modelname].values())
 
     def get_by_uids(
-        self, *, uids: List[Text], model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"]]
+        self, *, uids: List[str], model: Union[str, "DiffSyncModel", Type["DiffSyncModel"]]
     ) -> List["DiffSyncModel"]:
         """Get multiple objects from the store by their unique IDs/Keys and type.
 
@@ -89,11 +89,11 @@ class LocalStore(BaseStore):
             results.append(self._data[modelname][uid])
         return results
 
-    def add(self, *, obj: "DiffSyncModel"):
+    def add(self, *, obj: "DiffSyncModel") -> None:
         """Add a DiffSyncModel object to the store.
 
         Args:
-            obj (DiffSyncModel): Object to store
+            obj: Object to store
 
         Raises:
             ObjectAlreadyExists: if a different object with the same uid is already present.
@@ -113,11 +113,11 @@ class LocalStore(BaseStore):
 
         self._data[modelname][uid] = obj
 
-    def update(self, *, obj: "DiffSyncModel"):
+    def update(self, *, obj: "DiffSyncModel") -> None:
         """Update a DiffSyncModel object to the store.
 
         Args:
-            obj (DiffSyncModel): Object to update
+            obj: Object to update
         """
         modelname = obj.get_type()
         uid = obj.get_unique_id()
@@ -128,13 +128,13 @@ class LocalStore(BaseStore):
 
         self._data[modelname][uid] = obj
 
-    def remove_item(self, modelname: str, uid: str):
+    def remove_item(self, modelname: str, uid: str) -> None:
         """Remove one item from store."""
         if uid not in self._data[modelname]:
             raise ObjectNotFound(f"{modelname} {uid} not present in {str(self)}")
         del self._data[modelname][uid]
 
-    def count(self, *, model: Union[Text, "DiffSyncModel", Type["DiffSyncModel"], None] = None) -> int:
+    def count(self, *, model: Union[str, "DiffSyncModel", Type["DiffSyncModel"], None] = None) -> int:
         """Returns the number of elements of a specific model, or all elements in the store if unspecified."""
         if not model:
             return sum(len(entries) for entries in self._data.values())

--- a/diffsync/utils.py
+++ b/diffsync/utils.py
@@ -14,36 +14,41 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
 from collections import OrderedDict
-from typing import Iterator, List, Dict, Optional
+from typing import Iterator, List, Dict, Optional, TypeVar, Callable, Generic
 
 SPACE = "    "
 BRANCH = "│   "
 TEE = "├── "
 LAST = "└── "
 
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
 
-def intersection(lst1, lst2) -> List:
+
+def intersection(lst1: List[T], lst2: List[T]) -> List[T]:
     """Calculate the intersection of two lists, with ordering based on the first list."""
     lst3 = [value for value in lst1 if value in lst2]
     return lst3
 
 
-def symmetric_difference(lst1, lst2) -> List:
+def symmetric_difference(lst1: List[T], lst2: List[T]) -> List[T]:
     """Calculate the symmetric difference of two lists."""
-    return sorted(set(lst1) ^ set(lst2))
+    # Type hinting this correct is kind of hard to do. _Probably_ the solution is using typing.Protocol to ensure the
+    # set members support the ^ operator / set.symmetric_difference, but I decided this wasn't worth figuring out.
+    return sorted(set(lst1) ^ set(lst2))  # type: ignore[type-var]
 
 
-class OrderedDefaultDict(OrderedDict):
+class OrderedDefaultDict(OrderedDict, Generic[K, V]):
     """A combination of collections.OrderedDict and collections.DefaultDict behavior."""
 
-    def __init__(self, dict_type):
+    def __init__(self, dict_type: Callable[[], V]) -> None:
         """Create a new OrderedDefaultDict."""
         self.factory = dict_type
         super().__init__(self)
 
-    def __missing__(self, key):
+    def __missing__(self, key: K) -> V:
         """When trying to access a nonexistent key, initialize the key value based on the internal factory."""
         self[key] = value = self.factory()
         return value
@@ -71,7 +76,7 @@ def tree_string(data: Dict, root: str) -> str:
     return "\n".join([root, *_tree(data)])
 
 
-def set_key(data: Dict, keys: List):
+def set_key(data: Dict, keys: List) -> None:
     """Set a nested dictionary key given a list of keys."""
     current_level = data
     for key in keys:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1573,6 +1573,17 @@ files = [
 cryptography = ">=35.0.0"
 
 [[package]]
+name = "types-python-slugify"
+version = "8.0.0.1"
+description = "Typing stubs for python-slugify"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-python-slugify-8.0.0.1.tar.gz", hash = "sha256:f2177d2e65ecf2eca742d28fbf236a8d919a72e68272d1d748c3fe965e5ea3ab"},
+    {file = "types_python_slugify-8.0.0.1-py3-none-any.whl", hash = "sha256:1de288ce45c85627ef632c2b5098dedccfc7ebedb241d181ba69402f03704449"},
+]
+
+[[package]]
 name = "types-redis"
 version = "4.5.1.4"
 description = "Typing stubs for redis"
@@ -1588,6 +1599,20 @@ cryptography = ">=35.0.0"
 types-pyOpenSSL = "*"
 
 [[package]]
+name = "types-requests"
+version = "2.28.11.15"
+description = "Typing stubs for requests"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-requests-2.28.11.15.tar.gz", hash = "sha256:fc8eaa09cc014699c6b63c60c2e3add0c8b09a410c818b5ac6e65f92a26dde09"},
+    {file = "types_requests-2.28.11.15-py3-none-any.whl", hash = "sha256:a05e4c7bc967518fba5789c341ea8b0c942776ee474c7873129a61161978e586"},
+]
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
 name = "types-toml"
 version = "0.10.8.5"
 description = "Typing stubs for toml"
@@ -1596,6 +1621,17 @@ python-versions = "*"
 files = [
     {file = "types-toml-0.10.8.5.tar.gz", hash = "sha256:bf80fce7d2d74be91148f47b88d9ae5adeb1024abef22aa2fdbabc036d6b8b3c"},
     {file = "types_toml-0.10.8.5-py3-none-any.whl", hash = "sha256:2432017febe43174af0f3c65f03116e3d3cf43e7e1406b8200e106da8cf98992"},
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.8"
+description = "Typing stubs for urllib3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.8.tar.gz", hash = "sha256:ecf43c42d8ee439d732a1110b4901e9017a79a38daca26f08e42c8460069392c"},
+    {file = "types_urllib3-1.26.25.8-py3-none-any.whl", hash = "sha256:95ea847fbf0bf675f50c8ae19a665baedcf07e6b4641662c4c3c72e7b2edf1a9"},
 ]
 
 [[package]]
@@ -1746,4 +1782,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "37892839cc3207d00936d4f2d47780725bc0c299e1b1372a0bb4aba8907fe379"
+content-hash = "2213a75a00f27293bb23f2a74792c2f8e46b97148e9197ddf620c9239d88b634"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ redis = {version = "^4.3", optional = true}
 [tool.poetry.extras]
 redis = ["redis"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "*"
 pyyaml = "*"
 black = "*"
@@ -47,6 +47,8 @@ toml = "*"
 types-toml = "*"
 types-redis = "*"
 pytest-redis = "^2.4.0"
+types-requests = "^2.28.11.15"
+types-python-slugify = "^8.0.0.1"
 
 [tool.black]
 line-length = 120
@@ -101,6 +103,7 @@ testpaths = [
 
 [tool.mypy]
 warn_unused_configs = true
+disallow_untyped_defs = true
 ignore_missing_imports = true
 
 [build-system]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import ClassVar, List, Mapping, Optional, Tuple
+from typing import ClassVar, List, Optional, Tuple, Dict
 
 import pytest
 
@@ -35,7 +35,7 @@ class ErrorProneModelMixin:
     _counter: ClassVar[int] = 0
 
     @classmethod
-    def create(cls, diffsync: DiffSync, ids: Mapping, attrs: Mapping):
+    def create(cls, diffsync: DiffSync, ids: Dict, attrs: Dict):
         """As DiffSyncModel.create(), but periodically throw exceptions."""
         cls._counter += 1
         if not cls._counter % 5:
@@ -44,7 +44,7 @@ class ErrorProneModelMixin:
             return None  # non-fatal error
         return super().create(diffsync, ids, attrs)  # type: ignore
 
-    def update(self, attrs: Mapping):
+    def update(self, attrs: Dict):
         """As DiffSyncModel.update(), but periodically throw exceptions."""
         # pylint: disable=protected-access
         self.__class__._counter += 1
@@ -69,11 +69,11 @@ class ExceptionModelMixin:
     """Test class that always throws exceptions when creating/updating/deleting instances."""
 
     @classmethod
-    def create(cls, diffsync: DiffSync, ids: Mapping, attrs: Mapping):
+    def create(cls, diffsync: DiffSync, ids: Dict, attrs: Dict):
         """As DiffSyncModel.create(), but always throw exceptions."""
         raise NotImplementedError
 
-    def update(self, attrs: Mapping):
+    def update(self, attrs: Dict):
         """As DiffSyncModel.update(), but always throw exceptions."""
         raise NotImplementedError
 


### PR DESCRIPTION
Closes #175. Things that happened here:
- Fully type hint all function/method definitions
- Active `disallow_untyped_defs` in mypy config in `pyproject.toml`
- Replacing `Mapping` with `Dict`, `Collection` with `List` and `Text` with `str`, because all our mappings are dicts anyway, collections are lists (3.9 could use `dict`/`list`, maybe we can drop 3.8 support with 2.0?) and `Text` is only needed for backwards compatibility with Python 2.x which we aren't offering
