### PR TITLE
Simplify model interface

### DIFF
--- a/diffsync/enum.py
+++ b/diffsync/enum.py
@@ -104,3 +104,10 @@ class DiffSyncActions:  # pylint: disable=too-few-public-methods
     DELETE = "delete"
     SKIP = "skip"
     NO_CHANGE = None
+
+
+class DiffSyncFieldType(enum.Enum):
+    """Enum that details which type of field a mode field is."""
+    ATTRIBUTE = "attribute"
+    IDENTIFIER = "identifier"
+    CHILDREN = "children"

--- a/examples/01-multiple-data-sources/models.py
+++ b/examples/01-multiple-data-sources/models.py
@@ -14,46 +14,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Optional
-from diffsync import DiffSyncModel
+from typing import List, Optional, Annotated
+from diffsync import DiffSyncModel, DiffSyncFieldType
 
 
 class Site(DiffSyncModel):
     """Example model of a geographic Site."""
 
     _modelname = "site"
-    _identifiers = ("name",)
     _shortname = ()
-    _attributes = ()
-    _children = {"device": "devices"}
 
-    name: str
-    devices: List = []
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    devices: Annotated[List, DiffSyncFieldType.CHILDREN, "device"] = []
 
 
 class Device(DiffSyncModel):
     """Example model of a network Device."""
 
     _modelname = "device"
-    _identifiers = ("name",)
-    _attributes = ()
-    _children = {"interface": "interfaces"}
 
-    name: str
-    site_name: Optional[str]  # note that this attribute is NOT included in _attributes
-    role: Optional[str]  # note that this attribute is NOT included in _attributes
-    interfaces: List = []
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    site_name: Optional[str]  # note that this attribute is NOT annotated
+    role: Optional[str]  # note that this attribute is NOT annotated
+    interfaces: Annotated[List, DiffSyncFieldType.CHILDREN, "interface"] = []
 
 
 class Interface(DiffSyncModel):
     """Example model of a network Interface."""
 
     _modelname = "interface"
-    _identifiers = ("device_name", "name")
     _shortname = ("name",)
-    _attributes = ("description",)
 
-    name: str
-    device_name: str
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    device_name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
 
-    description: Optional[str]
+    description: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]

--- a/examples/02-callback-function/main.py
+++ b/examples/02-callback-function/main.py
@@ -16,8 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import random
+from typing import Annotated
 
-from diffsync import DiffSync, DiffSyncModel
+from diffsync import DiffSync, DiffSyncModel, DiffSyncFieldType
 from diffsync.logging import enable_console_logging
 
 
@@ -25,9 +26,8 @@ class Number(DiffSyncModel):
     """Simple model that consists only of a number."""
 
     _modelname = "number"
-    _identifiers = ("number",)
 
-    number: int
+    number: Annotated[int, DiffSyncFieldType.IDENTIFIER]
 
 
 class DiffSync1(DiffSync):

--- a/examples/03-remote-system/models.py
+++ b/examples/03-remote-system/models.py
@@ -1,22 +1,19 @@
 """Main DiffSync models for example3."""
-from typing import List, Optional
-from diffsync import DiffSyncModel
+from typing import List, Optional, Annotated
+from diffsync import DiffSyncModel, DiffSyncFieldType
 
 
 class Region(DiffSyncModel):
     """Example model of a geographic region."""
 
     _modelname = "region"
-    _identifiers = ("slug",)
-    _attributes = ("name",)
 
-    # By listing country as a child to Region
+    slug: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    name: Annotated[str, DiffSyncFieldType.ATTRIBUTE]
+
+    # By annotating country as a child to Region
     # DiffSync will be able to recursively compare all regions including all their children
-    _children = {"country": "countries"}
-
-    slug: str
-    name: str
-    countries: List[str] = []
+    countries: Annotated[List[str], DiffSyncFieldType.CHILDREN, "country"] = []
 
 
 class Country(DiffSyncModel):
@@ -26,10 +23,8 @@ class Country(DiffSyncModel):
     """
 
     _modelname = "country"
-    _identifiers = ("slug",)
-    _attributes = ("name", "region", "population")
 
-    slug: str
-    name: str
-    region: str
-    population: Optional[int]
+    slug: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    name: Annotated[str, DiffSyncFieldType.ATTRIBUTE]
+    region: Annotated[str, DiffSyncFieldType.ATTRIBUTE]
+    population: Annotated[Optional[int], DiffSyncFieldType.ATTRIBUTE]

--- a/examples/04-get-update-instantiate/models.py
+++ b/examples/04-get-update-instantiate/models.py
@@ -14,45 +14,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Optional
-from diffsync import DiffSyncModel
+from typing import List, Optional, Annotated
+from diffsync import DiffSyncModel, DiffSyncFieldType
 
 
 class Site(DiffSyncModel):
     """Example model of a geographic Site."""
 
     _modelname = "site"
-    _identifiers = ("name",)
     _shortname = ()
-    _attributes = ()
 
-    name: str
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
 
 
 class Device(DiffSyncModel):
     """Example model of a network Device."""
 
     _modelname = "device"
-    _identifiers = ("name",)
-    _attributes = ()
-    _children = {"interface": "interfaces", "site": "sites"}
 
-    name: str
-    site_name: Optional[str]  # note that this attribute is NOT included in _attributes
-    role: Optional[str]  # note that this attribute is NOT included in _attributes
-    interfaces: List = []
-    sites: List = []
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    site_name: Optional[str]  # note that this attribute is NOT annotated
+    role: Optional[str]  # note that this attribute is NOT annotated
+    interfaces: Annotated[List[str], DiffSyncFieldType.CHILDREN, "interface"] = []
+    sites: Annotated[List[str], DiffSyncFieldType.CHILDREN, "site"] = []
 
 
 class Interface(DiffSyncModel):
     """Example model of a network Interface."""
 
     _modelname = "interface"
-    _identifiers = ("device_name", "name")
     _shortname = ("name",)
-    _attributes = ("description",)
 
-    name: str
-    device_name: str
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    device_name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
 
-    description: Optional[str]
+    description: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]

--- a/examples/05-nautobot-peeringdb/models.py
+++ b/examples/05-nautobot-peeringdb/models.py
@@ -1,8 +1,8 @@
 """DiffSyncModel subclasses for Nautobot-PeeringDB data sync."""
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Annotated
 from uuid import UUID
 
-from diffsync import DiffSyncModel
+from diffsync import DiffSyncModel, DiffSyncFieldType
 
 
 class RegionModel(DiffSyncModel):
@@ -10,22 +10,15 @@ class RegionModel(DiffSyncModel):
 
     # Metadata about this model
     _modelname = "region"
-    _identifiers = ("name",)
-    _attributes = (
-        "slug",
-        "description",
-        "parent_name",
-    )
-    _children = {"site": "sites"}
 
     # Data type declarations for all identifiers and attributes
-    name: str
-    slug: str
-    description: Optional[str]
-    parent_name: Optional[str]  # may be None
-    sites: List = []
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    slug: Annotated[str, DiffSyncFieldType.ATTRIBUTE]
+    description: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]
+    parent_name: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]
+    sites: Annotated[List, DiffSyncFieldType.CHILDREN, "sites"] = []
 
-    # Not in _attributes or _identifiers, hence not included in diff calculations
+    # Not annotated, hence not included in diff calculations
     pk: Optional[UUID]
 
 
@@ -34,25 +27,15 @@ class SiteModel(DiffSyncModel):
 
     # Metadata about this model
     _modelname = "site"
-    _identifiers = ("name",)
-    # To keep this example simple, we don't include **all** attributes of a Site here. But you could!
-    _attributes = (
-        "slug",
-        "status_slug",
-        "region_name",
-        "description",
-        "latitude",
-        "longitude",
-    )
 
-    # Data type declarations for all identifiers and attributes
-    name: str
-    slug: str
-    status_slug: str
-    region_name: Optional[str]  # may be None
-    description: Optional[str]
-    latitude: Optional[float]
-    longitude: Optional[float]
+    # To keep this example simple, we don't include **all** attributes of a Site here. But you could!
+    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    slug: Annotated[str, DiffSyncFieldType.ATTRIBUTE]
+    status_slug: Annotated[str, DiffSyncFieldType.ATTRIBUTE]
+    region_name: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]
+    description: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]
+    latitude: Annotated[Optional[float], DiffSyncFieldType.ATTRIBUTE]
+    longitude: Annotated[Optional[float], DiffSyncFieldType.ATTRIBUTE]
 
     # Not in _attributes or _identifiers, hence not included in diff calculations
     pk: Optional[Union[UUID, int]]

--- a/examples/06-ip-prefixes/models.py
+++ b/examples/06-ip-prefixes/models.py
@@ -1,16 +1,14 @@
 """DiffSync models."""
-from typing import Optional
-from diffsync import DiffSyncModel
+from typing import Optional, Annotated
+from diffsync import DiffSyncModel, DiffSyncFieldType
 
 
 class Prefix(DiffSyncModel):
     """Example model of a Prefix."""
 
     _modelname = "prefix"
-    _identifiers = ("prefix",)
-    _attributes = ("vrf", "vlan_id", "tenant")
 
-    prefix: str
-    vrf: Optional[str]
-    vlan_id: Optional[int]
-    tenant: Optional[str]
+    prefix: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+    vrf: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]
+    vlan_id: Annotated[Optional[int], DiffSyncFieldType.ATTRIBUTE]
+    tenant: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]

--- a/tests/unit/test_diffsync_model_flags.py
+++ b/tests/unit/test_diffsync_model_flags.py
@@ -14,12 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List
+from typing import List, Annotated
 
 import pytest
 
 from diffsync import DiffSync, DiffSyncModel
-from diffsync.enum import DiffSyncModelFlags
+from diffsync.enum import DiffSyncModelFlags, DiffSyncFieldType
 from diffsync.exceptions import ObjectNotFound
 
 
@@ -121,9 +121,8 @@ def test_diffsync_diff_with_natural_deletion_order():
 
     class TestModelChild(DiffSyncModel):  # pylint: disable=missing-class-docstring
         _modelname = "child"
-        _identifiers = ("name",)
 
-        name: str
+        name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
 
         def delete(self):
             call_order.append(self.name)
@@ -131,11 +130,9 @@ def test_diffsync_diff_with_natural_deletion_order():
 
     class TestModelParent(DiffSyncModel):  # pylint: disable=missing-class-docstring
         _modelname = "parent"
-        _identifiers = ("name",)
-        _children = {"child": "children"}
 
-        name: str
-        children: List[TestModelChild] = []
+        name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
+        children: Annotated[List[TestModelChild], DiffSyncFieldType.CHILDREN, "child"] = []
 
         def delete(self):
             call_order.append(self.name)


### PR DESCRIPTION
This is a draft of an attempt to simplify the interface for defining models a bit. Here is what an example model definition now might look like:

```python
from typing import Annotated, List. Optional

from diffsync.enum import DiffSyncFieldtype
from diffsync import DIffSyncModel


class City(DiffSyncModel):
    _modelname = "city"

    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
    population: Annotated[int, DiffSyncFieldType.ATTRIBUTE]


class Country(DebugModel):
    _modelname = "country"

    name: Annotated[str, DiffSyncFieldType.IDENTIFIER]
    iso_code: Annotated[Optional[str], DiffSyncFieldType.ATTRIBUTE]
    cities: Annotated[List[City], DiffSyncFieldType.CHILDREN, "city"] = []
```

## Open points

- [ ] Evaluate, whether this breaking change (eyeing at 2.0) is worth it
- [ ] Documentation
- [ ] Think about further possibilites for simplification