### PR TITLE
Documentation fix.

### DIFF
--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -1,5 +1,5 @@
 #########
-Upgrading
+Getting started
 #########
 
 .. mdinclude:: 01-getting-started.md


### PR DESCRIPTION
Fix invalid upgrading section name in https://diffsync.readthedocs.io/en/latest/getting_started/index.html