### PR TITLE
Fix Bug with deepcopy

### DIFF
--- a/changes/339.fixed
+++ b/changes/339.fixed
@@ -1,0 +1,1 @@
+Fixed bug with deepcopy in dunder new.

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -488,7 +488,7 @@ class Adapter:  # pylint: disable=too-many-public-methods
         for key, value in kwargs.items():
             try:
                 meta_kwargs[key] = deepcopy(value)
-            except (TypeError, AttributeError):
+            except Exception:
                 # Some objects (e.g. Kafka Consumer, DB connections) cannot be deep copied
                 meta_kwargs[key] = value
         instance = super().__new__(cls)

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -488,7 +488,7 @@ class Adapter:  # pylint: disable=too-many-public-methods
         for key, value in kwargs.items():
             try:
                 meta_kwargs[key] = deepcopy(value)
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 # Some objects (e.g. Kafka Consumer, DB connections) cannot be deep copied
                 meta_kwargs[key] = value
         instance = super().__new__(cls)


### PR DESCRIPTION
This PR is to expand the Exceptions that are caught during the instantiation of an Adapter by the deepcopy action.