### PR TITLE
Release v2.2.2

### DIFF
--- a/changes/339.fixed
+++ b/changes/339.fixed
@@ -1,0 +1,1 @@
+Fixed bug with deepcopy in dunder new.

--- a/changes/339.fixed
+++ b/changes/339.fixed
@@ -1,1 +1,0 @@
-Fixed bug with deepcopy in dunder new.

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -488,7 +488,7 @@ class Adapter:  # pylint: disable=too-many-public-methods
         for key, value in kwargs.items():
             try:
                 meta_kwargs[key] = deepcopy(value)
-            except (TypeError, AttributeError):
+            except Exception:
                 # Some objects (e.g. Kafka Consumer, DB connections) cannot be deep copied
                 meta_kwargs[key] = value
         instance = super().__new__(cls)

--- a/diffsync/__init__.py
+++ b/diffsync/__init__.py
@@ -488,7 +488,7 @@ class Adapter:  # pylint: disable=too-many-public-methods
         for key, value in kwargs.items():
             try:
                 meta_kwargs[key] = deepcopy(value)
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 # Some objects (e.g. Kafka Consumer, DB connections) cannot be deep copied
                 meta_kwargs[key] = value
         instance = super().__new__(cls)

--- a/docs/admin/release_notes/version_2.2.md
+++ b/docs/admin/release_notes/version_2.2.md
@@ -18,3 +18,9 @@ Remove Python 3.9 support as it's EOL.
 
 - [#321](https://github.com/networktocode/diffsync/issues/321) - Fixed CI release workflow.
 - Rebaked from the cookie `main`.
+
+## [v2.2.2 (2026-03-11)](https://github.com/networktocode/diffsync/releases/tag/v2.2.2)
+
+### Fixed
+
+- [#339](https://github.com/networktocode/diffsync/issues/339) - Fixed bug with deepcopy in dunder new.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "diffsync"
-version = "2.2.2a0"
+version = "2.2.2"
 description = "Library to easily sync/diff/update 2 different data sources"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "diffsync"
-version = "2.2.1"
+version = "2.2.2a0"
 description = "Library to easily sync/diff/update 2 different data sources"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v2.2.2 (2026-03-11)](https://github.com/networktocode/diffsync/releases/tag/v2.2.2)

### Fixed

- [#339](https://github.com/networktocode/diffsync/issues/339) - Fixed bug with deepcopy in dunder new.
